### PR TITLE
feat: add GOEVAL_TRACE for judge I/O tracing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,9 @@ Metrics: `Faithfulness`, `Hallucination`, `AnswerRelevancy`, `ContextPrecision`,
 - `Result.Metric` and `Result.Latency` are filled by Runner if empty/zero.
 - Low scores call `tb.Errorf` (non-fatal); judge errors call `tb.Fatalf` (fatal).
 - `adapters/` directory contains external integrations (e.g. OpenAI judge).
+
+## Testing env-gated behavior
+
+- Tests that rely on an env var being **unset** must explicitly call `t.Setenv(EnvVar, "")` at the start. Never assume the inherited environment is clean — a developer shell or CI job may have exported the var globally.
+- Tests that rely on an env var being **set** must call `t.Setenv(EnvVar, "1")` at the start (already standard practice).
+- This applies to `GOEVAL`, `GOEVAL_TRACE`, and any future env gates.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ GOEVAL=1 go test ./...
 
 Unset `GOEVAL` and evals skip. That keeps CI and local runs safe by default.
 
+### Tracing judge I/O
+
+Set `GOEVAL_TRACE=1` alongside `GOEVAL=1` to dump every judge prompt and
+response via `t.Log`. Output respects `-v` and test buffering.
+
+```bash
+GOEVAL=1 GOEVAL_TRACE=1 go test -v -run TestFaithfulness
+```
+
+> **Warning:** traces contain full prompt + response text. May include PII
+> or sensitive eval payloads. Do not enable in shared CI logs.
+
 ## Metrics
 
 | Metric             | Measures                                               | Default threshold |

--- a/eval.go
+++ b/eval.go
@@ -60,8 +60,10 @@ func (r *Runner) Run(tb testing.TB, m Metric, c Case) Result {
 	ctx, cancel := runnerContext(r.timeout)
 	defer cancel()
 
+	judge := maybeTrace(r.judge, tb)
+
 	start := time.Now()
-	result, err := m.Score(ctx, r.judge, c)
+	result, err := m.Score(ctx, judge, c)
 	if result.Metric == "" {
 		result.Metric = m.Name()
 	}

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,62 @@
+package eval
+
+import (
+	"context"
+	"os"
+)
+
+// TraceEnvVar is the environment variable that enables judge I/O tracing.
+// When set to any non-empty value, every judge prompt and response is
+// logged via the testing.TB passed to Runner.Run.
+const TraceEnvVar = "GOEVAL_TRACE"
+
+type traceTB interface {
+	Helper()
+	Logf(format string, args ...any)
+}
+
+type tracingJudge struct {
+	inner Judge
+	tb    traceTB
+}
+
+func (t *tracingJudge) Evaluate(ctx context.Context, prompt string) (JudgeResponse, error) {
+	t.tb.Helper()
+	t.tb.Logf("[goeval-trace] prompt:\n%s", prompt)
+	resp, err := t.inner.Evaluate(ctx, prompt)
+	if err != nil {
+		t.tb.Logf("[goeval-trace] error: %v", err)
+		return resp, err
+	}
+	t.tb.Logf("[goeval-trace] response score=%.3f tokens=%d reason=%q",
+		resp.Score, resp.Tokens, resp.Reason)
+	return resp, nil
+}
+
+type tracingRawJudge struct {
+	*tracingJudge
+	raw RawJudge
+}
+
+func (t *tracingRawJudge) EvaluateRaw(ctx context.Context, prompt string) (RawJudgeResponse, error) {
+	t.tb.Helper()
+	t.tb.Logf("[goeval-trace] prompt:\n%s", prompt)
+	resp, err := t.raw.EvaluateRaw(ctx, prompt)
+	if err != nil {
+		t.tb.Logf("[goeval-trace] error: %v", err)
+		return resp, err
+	}
+	t.tb.Logf("[goeval-trace] raw response tokens=%d:\n%s", resp.Tokens, resp.Content)
+	return resp, nil
+}
+
+func maybeTrace(j Judge, tb traceTB) Judge {
+	if os.Getenv(TraceEnvVar) == "" {
+		return j
+	}
+	base := &tracingJudge{inner: j, tb: tb}
+	if raw, ok := j.(RawJudge); ok {
+		return &tracingRawJudge{tracingJudge: base, raw: raw}
+	}
+	return base
+}

--- a/trace.go
+++ b/trace.go
@@ -51,6 +51,9 @@ func (t *tracingRawJudge) EvaluateRaw(ctx context.Context, prompt string) (RawJu
 }
 
 func maybeTrace(j Judge, tb traceTB) Judge {
+	if j == nil {
+		return nil
+	}
 	if os.Getenv(TraceEnvVar) == "" {
 		return j
 	}

--- a/trace_test.go
+++ b/trace_test.go
@@ -1,0 +1,158 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type fakeTraceTB struct {
+	mu   sync.Mutex
+	logs []string
+}
+
+func (f *fakeTraceTB) Helper() {}
+func (f *fakeTraceTB) Logf(format string, args ...any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.logs = append(f.logs, fmt.Sprintf(format, args...))
+}
+
+type mockRawJudge struct {
+	Response   RawJudgeResponse
+	ParsedResp JudgeResponse
+	Err        error
+}
+
+func (m *mockRawJudge) EvaluateRaw(_ context.Context, _ string) (RawJudgeResponse, error) {
+	if m.Err != nil {
+		return RawJudgeResponse{}, m.Err
+	}
+	return m.Response, nil
+}
+
+func (m *mockRawJudge) Evaluate(_ context.Context, _ string) (JudgeResponse, error) {
+	if m.Err != nil {
+		return JudgeResponse{}, m.Err
+	}
+	return m.ParsedResp, nil
+}
+
+func TestMaybeTrace_EnvUnset_ReturnsIdentity(t *testing.T) {
+	j := &MockJudge{}
+	tb := &fakeTraceTB{}
+
+	got := maybeTrace(j, tb)
+
+	if got != j {
+		t.Fatal("maybeTrace should return the same pointer when env is unset")
+	}
+}
+
+func TestMaybeTrace_EnvSet_PlainJudge(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+
+	j := &MockJudge{
+		Response: JudgeResponse{Score: 0.9, Reason: "good", Tokens: 10},
+	}
+	tb := &fakeTraceTB{}
+
+	wrapped := maybeTrace(j, tb)
+	resp, err := wrapped.Evaluate(context.Background(), "hello prompt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Score != 0.9 {
+		t.Fatalf("expected score 0.9, got %.3f", resp.Score)
+	}
+
+	if len(tb.logs) != 2 {
+		t.Fatalf("expected 2 log lines, got %d: %v", len(tb.logs), tb.logs)
+	}
+	if tb.logs[0] != "[goeval-trace] prompt:\nhello prompt" {
+		t.Fatalf("unexpected prompt log: %q", tb.logs[0])
+	}
+	if tb.logs[1] != `[goeval-trace] response score=0.900 tokens=10 reason="good"` {
+		t.Fatalf("unexpected response log: %q", tb.logs[1])
+	}
+}
+
+func TestMaybeTrace_EnvSet_RawJudge(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+
+	raw := &mockRawJudge{
+		Response:   RawJudgeResponse{Content: `{"faithfulness": {"score": 0.8}}`, Tokens: 5},
+		ParsedResp: JudgeResponse{Score: 0.8},
+	}
+	tb := &fakeTraceTB{}
+
+	wrapped := maybeTrace(raw, tb)
+
+	// Type assertion must still succeed
+	_, ok := wrapped.(RawJudge)
+	if !ok {
+		t.Fatal("wrapped judge should still satisfy RawJudge type assertion")
+	}
+
+	resp, err := wrapped.(RawJudge).EvaluateRaw(context.Background(), "raw prompt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != `{"faithfulness": {"score": 0.8}}` {
+		t.Fatalf("unexpected content: %q", resp.Content)
+	}
+
+	if len(tb.logs) != 2 {
+		t.Fatalf("expected 2 log lines, got %d: %v", len(tb.logs), tb.logs)
+	}
+	if tb.logs[0] != "[goeval-trace] prompt:\nraw prompt" {
+		t.Fatalf("unexpected prompt log: %q", tb.logs[0])
+	}
+	if tb.logs[1] != "[goeval-trace] raw response tokens=5:\n{\"faithfulness\": {\"score\": 0.8}}" {
+		t.Fatalf("unexpected raw response log: %q", tb.logs[1])
+	}
+}
+
+func TestMaybeTrace_ErrorPath(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+
+	sentinel := errors.New("boom")
+	j := &MockJudge{Err: sentinel}
+	tb := &fakeTraceTB{}
+
+	wrapped := maybeTrace(j, tb)
+	_, err := wrapped.Evaluate(context.Background(), "fail prompt")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got: %v", err)
+	}
+
+	if len(tb.logs) != 2 {
+		t.Fatalf("expected 2 log lines (prompt + error), got %d: %v", len(tb.logs), tb.logs)
+	}
+	if tb.logs[1] != "[goeval-trace] error: boom" {
+		t.Fatalf("unexpected error log: %q", tb.logs[1])
+	}
+}
+
+func TestMaybeTrace_SetenvMidTest(t *testing.T) {
+	j := &MockJudge{}
+	tb := &fakeTraceTB{}
+
+	// Env unset → identity
+	got := maybeTrace(j, tb)
+	if got != j {
+		t.Fatal("expected identity when env unset")
+	}
+
+	// Set env → wrapped
+	t.Setenv(TraceEnvVar, "1")
+	got2 := maybeTrace(j, tb)
+	if got2 == j {
+		t.Fatal("expected wrapped judge when env set")
+	}
+}

--- a/trace_test.go
+++ b/trace_test.go
@@ -80,6 +80,16 @@ func TestMaybeTrace_EnvSet_PlainJudge(t *testing.T) {
 	}
 }
 
+func TestMaybeTrace_EnvSet_NilJudgeReturnsNil(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+	tb := &fakeTraceTB{}
+
+	got := maybeTrace(nil, tb)
+	if got != nil {
+		t.Fatalf("expected nil judge to remain nil when tracing is enabled, got %T", got)
+	}
+}
+
 func TestMaybeTrace_EnvSet_RawJudge(t *testing.T) {
 	t.Setenv(TraceEnvVar, "1")
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -41,6 +41,7 @@ func (m *mockRawJudge) Evaluate(_ context.Context, _ string) (JudgeResponse, err
 }
 
 func TestMaybeTrace_EnvUnset_ReturnsIdentity(t *testing.T) {
+	t.Setenv(TraceEnvVar, "")
 	j := &MockJudge{}
 	tb := &fakeTraceTB{}
 
@@ -140,6 +141,7 @@ func TestMaybeTrace_ErrorPath(t *testing.T) {
 }
 
 func TestMaybeTrace_SetenvMidTest(t *testing.T) {
+	t.Setenv(TraceEnvVar, "")
 	j := &MockJudge{}
 	tb := &fakeTraceTB{}
 


### PR DESCRIPTION
## Summary

- Add `GOEVAL_TRACE=1` env var that dumps every judge prompt and response via `t.Log`
- Wraps `Judge` (and `RawJudge` when present) transparently so type assertions like `Compound`'s still work
- Zero API change — existing tests and metrics unaffected

## Changes

| File | Description |
|------|-------------|
| `trace.go` | `tracingJudge`, `tracingRawJudge`, `maybeTrace` wrapper factory |
| `trace_test.go` | 5 test cases: identity, plain judge, raw judge, error path, mid-test setenv |
| `eval.go` | 2-line addition: `judge := maybeTrace(r.judge, tb)` before `m.Score` |
| `README.md` | Tracing section with usage example and PII warning |

## Design

- `traceTB` interface (not `testing.TB`) avoids unexported method and enables mocking
- Per-call `os.Getenv` allows `t.Setenv` mid-test
- `RawJudge` type assertion preserved by checking at wrap-time
- Output respects `-v` and test buffering via `tb.Logf`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Judge I/O tracing via GOEVAL_TRACE=1 to log prompts, responses, tokens, and errors during tests.

* **Documentation**
  * Added tracing guide with setup example and security warning about sensitive data exposure.
  * Documented conventions for tests to explicitly set/unset env vars (including GOEVAL and GOEVAL_TRACE).

* **Tests**
  * Added tests validating tracing behavior, log output, and env-var gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GOEVAL_TRACE=1` to trace all judge prompts and responses during tests without changing the public API. Keeps type assertions intact and leaves existing tests and metrics unaffected.

- **New Features**
  - Enable `GOEVAL_TRACE=1` to log judge I/O via `tb.Logf`; respects `-v` and test buffering.
  - Transparent wrapper for `Judge` and `RawJudge`; reads the env var per call. Docs updated in `README.md` (usage + PII warning) and `AGENTS.md` (env-gated testing rules).

- **Bug Fixes**
  - Tests explicitly unset `GOEVAL_TRACE` in identity cases to avoid inherited env leakage.
  - Preserve nil judge when `GOEVAL_TRACE` is enabled.

<sup>Written for commit f8b7a26cb05c99d74546ad549a514b965cfc32ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

