### PR TITLE
Add #8 eval reporting prereqs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,10 @@ Core interfaces in root package:
 
 | Type | Purpose |
 |------|---------|
-| `Judge` | LLM provider abstraction — sends prompt, returns `{score, reason, tokens}`. Must be concurrency-safe. |
+| `Judge` | LLM provider abstraction — sends prompt, returns `{score, reason, tokens, prompt_tokens, completion_tokens}`. Must be concurrency-safe. |
 | `Metric` | Evaluation contract — `Score(ctx, judge, case) → Result`. Stateless value types. |
 | `Case` | Evaluation input — `Input`, `Output`, `Expected`, `Context`, `Metadata`. |
-| `Result` | Score output — `Score`, `Passed`, `Reason`, `Latency`, `Tokens`. |
+| `Result` | Score output — `Score`, `Passed`, `Reason`, `Latency`, `Tokens`, `PromptTokens`, `CompletionTokens`. |
 | `Runner` | Ties Judge + Metric + Case together, asserts via `testing.TB`. Shared across parallel subtests. |
 
 Metrics: `Faithfulness`, `Hallucination`, `AnswerRelevancy`, `ContextPrecision`, `GEval`, `Precheck`, `Compound`, `Deterministic` (JSONPath, FieldCount).
@@ -53,6 +53,18 @@ Metrics: `Faithfulness`, `Hallucination`, `AnswerRelevancy`, `ContextPrecision`,
 - `Result.Metric` and `Result.Latency` are filled by Runner if empty/zero.
 - Low scores call `tb.Errorf` (non-fatal); judge errors call `tb.Fatalf` (fatal).
 - `adapters/` directory contains external integrations (e.g. OpenAI judge).
+
+### Case metadata conventions
+
+`Case.Metadata` is user-defined and copied into JSONL results. The library does
+not interpret these keys, but eval suites and agent reports should use them
+consistently:
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `flow` | string | Logical agent flow exercised (e.g. `rag.retrieval`, `tool_use.search`) |
+| `tier` | string | Case selection tier: `critical`, `standard`, or `extended` |
+| `dataset` | string | Dataset name and version/provenance |
 
 ## Testing env-gated behavior
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `RunResult.Metadata` in JSONL result sinks, copied from `Case.Metadata` by default
+- Split token counts (`PromptTokens`, `CompletionTokens`) on judge responses, results, and JSONL sink rows
+- `WithCaseFilter` runner option for skipping cases by metadata or custom predicates
 
 ## [v0.2.0] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,19 @@ r := eval.NewRunner(judge, eval.WithResultSink(eval.DefaultResultSink()))
 
 When `GOEVAL_RESULTS_DIR` is set, `DefaultResultSink` writes
 `results.jsonl` in that directory. Each row includes `timestamp`, `test_name`,
-`metric`, `score`, `passed`, `reason`, `tokens`, `latency_ns`, optional
-`dimensions`, and optional `metadata`. `Runner` copies `Case.Metadata` into
-the run result unless a metric sets `Result.Metadata` explicitly.
+`metric`, `score`, `passed`, `reason`, `tokens`, optional `prompt_tokens` and
+`completion_tokens`, `latency_ns`, optional `dimensions`, and optional
+`metadata`. `Runner` copies `Case.Metadata` into the run result unless a metric
+sets `Result.Metadata` explicitly.
+
+Use `WithCaseFilter` to run a selected slice of cases, for example a
+critical-only CI path:
+
+```go
+r := eval.NewRunner(judge, eval.WithCaseFilter(func(c eval.Case) bool {
+	return c.Metadata["tier"] == "critical"
+}))
+```
 
 ## Writing your own `Judge`
 

--- a/adapters/openai/judge.go
+++ b/adapters/openai/judge.go
@@ -90,8 +90,10 @@ func (j *Judge) EvaluateRaw(ctx context.Context, prompt string) (eval.RawJudgeRe
 	}
 
 	return eval.RawJudgeResponse{
-		Content: resp.Choices[0].Message.Content,
-		Tokens:  resp.Usage.TotalTokens,
+		Content:          resp.Choices[0].Message.Content,
+		Tokens:           resp.Usage.TotalTokens,
+		PromptTokens:     resp.Usage.PromptTokens,
+		CompletionTokens: resp.Usage.CompletionTokens,
 	}, nil
 }
 
@@ -105,9 +107,11 @@ func (j *Judge) Evaluate(ctx context.Context, prompt string) (eval.JudgeResponse
 	parsed, parseErr := parseJudgeJSON(raw.Content)
 	if parseErr == nil {
 		return eval.JudgeResponse{
-			Score:  *parsed.Score,
-			Reason: parsed.Reason,
-			Tokens: raw.Tokens,
+			Score:            *parsed.Score,
+			Reason:           parsed.Reason,
+			Tokens:           raw.Tokens,
+			PromptTokens:     raw.PromptTokens,
+			CompletionTokens: raw.CompletionTokens,
 		}, nil
 	}
 
@@ -122,9 +126,11 @@ func (j *Judge) Evaluate(ctx context.Context, prompt string) (eval.JudgeResponse
 	}
 
 	return eval.JudgeResponse{
-		Score:  *parsed.Score,
-		Reason: parsed.Reason,
-		Tokens: raw.Tokens + rawRetry.Tokens,
+		Score:            *parsed.Score,
+		Reason:           parsed.Reason,
+		Tokens:           raw.Tokens + rawRetry.Tokens,
+		PromptTokens:     raw.PromptTokens + rawRetry.PromptTokens,
+		CompletionTokens: raw.CompletionTokens + rawRetry.CompletionTokens,
 	}, nil
 }
 

--- a/adapters/openai/judge_test.go
+++ b/adapters/openai/judge_test.go
@@ -1,6 +1,14 @@
 package openaieval
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
 
 func TestParseJudgeJSON_Direct(t *testing.T) {
 	out, err := parseJudgeJSON(`{"score":0.75,"reason":"ok"}`)
@@ -42,4 +50,91 @@ func TestParseJudgeJSON_OutOfRange(t *testing.T) {
 	if _, err := parseJudgeJSON(`{"score":1.2,"reason":"bad"}`); err == nil {
 		t.Fatalf("expected out-of-range score error")
 	}
+}
+
+func TestEvaluateRawCopiesTokenSplit(t *testing.T) {
+	j, _ := newStubJudge(t, []stubCompletion{
+		{content: `{"score":0.9,"reason":"ok"}`, promptTokens: 3, completionTokens: 5},
+	})
+
+	resp, err := j.EvaluateRaw(context.Background(), "prompt")
+	if err != nil {
+		t.Fatalf("EvaluateRaw: %v", err)
+	}
+	if resp.Tokens != 8 || resp.PromptTokens != 3 || resp.CompletionTokens != 5 {
+		t.Fatalf("unexpected token fields: %+v", resp)
+	}
+}
+
+func TestEvaluateAggregatesRetryTokenSplit(t *testing.T) {
+	j, calls := newStubJudge(t, []stubCompletion{
+		{content: "not-json", promptTokens: 3, completionTokens: 2},
+		{content: `{"score":0.85,"reason":"ok"}`, promptTokens: 7, completionTokens: 4},
+	})
+
+	resp, err := j.Evaluate(context.Background(), "prompt")
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if *calls != 2 {
+		t.Fatalf("expected retry, got %d calls", *calls)
+	}
+	if resp.Score != 0.85 || resp.Tokens != 16 || resp.PromptTokens != 10 || resp.CompletionTokens != 6 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+type stubCompletion struct {
+	content          string
+	promptTokens     int
+	completionTokens int
+}
+
+func newStubJudge(t *testing.T, completions []stubCompletion) (*Judge, *int) {
+	t.Helper()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		idx := calls
+		if idx >= len(completions) {
+			idx = len(completions) - 1
+		}
+		calls++
+		completion := completions[idx]
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": 0,
+			"model":   openai.GPT4oMini,
+			"choices": []map[string]any{
+				{
+					"index": 0,
+					"message": map[string]any{
+						"role":    openai.ChatMessageRoleAssistant,
+						"content": completion.content,
+					},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]any{
+				"prompt_tokens":     completion.promptTokens,
+				"completion_tokens": completion.completionTokens,
+				"total_tokens":      completion.promptTokens + completion.completionTokens,
+			},
+		})
+		if err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	config := openai.DefaultConfig("test")
+	config.BaseURL = server.URL + "/v1"
+	return NewJudge(openai.NewClientWithConfig(config), openai.GPT4oMini), &calls
 }

--- a/adapters/openai/judge_test.go
+++ b/adapters/openai/judge_test.go
@@ -92,11 +92,17 @@ type stubCompletion struct {
 
 func newStubJudge(t *testing.T, completions []stubCompletion) (*Judge, *int) {
 	t.Helper()
+	if len(completions) == 0 {
+		t.Fatal("newStubJudge requires at least one completion")
+	}
 
 	calls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/chat/completions" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			msg := "unexpected path: " + r.URL.Path
+			t.Error(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
 		}
 
 		idx := calls
@@ -129,7 +135,9 @@ func newStubJudge(t *testing.T, completions []stubCompletion) (*Judge, *int) {
 			},
 		})
 		if err != nil {
-			t.Fatalf("encode response: %v", err)
+			msg := "encode response: " + err.Error()
+			t.Error(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
 		}
 	}))
 	t.Cleanup(server.Close)

--- a/compound.go
+++ b/compound.go
@@ -57,6 +57,8 @@ func (m Compound) Score(ctx context.Context, j Judge, c Case) (Result, error) {
 
 	start := time.Now()
 	totalTokens := 0
+	totalPromptTokens := 0
+	totalCompletionTokens := 0
 
 	attemptPrompt := prompt
 	const maxAttempts = 2
@@ -64,13 +66,21 @@ func (m Compound) Score(ctx context.Context, j Judge, c Case) (Result, error) {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		rawResp, evalErr := rawJudge.EvaluateRaw(ctx, attemptPrompt)
 		totalTokens += rawResp.Tokens
+		totalPromptTokens += rawResp.PromptTokens
+		totalCompletionTokens += rawResp.CompletionTokens
 		if evalErr != nil {
-			return Result{Metric: m.Name(), Latency: time.Since(start), Tokens: totalTokens}, fmt.Errorf("compound: judge: %w", evalErr)
+			return Result{
+				Metric:           m.Name(),
+				Latency:          time.Since(start),
+				Tokens:           totalTokens,
+				PromptTokens:     totalPromptTokens,
+				CompletionTokens: totalCompletionTokens,
+			}, fmt.Errorf("compound: judge: %w", evalErr)
 		}
 
 		dimensionResults, parseErr := parseCompoundDimensions(rawResp.Content, dimensions)
 		if parseErr == nil {
-			return buildCompoundResult(m.Name(), dimensionResults, time.Since(start), totalTokens), nil
+			return buildCompoundResult(m.Name(), dimensionResults, time.Since(start), totalTokens, totalPromptTokens, totalCompletionTokens), nil
 		}
 		lastParseErr = parseErr
 
@@ -80,9 +90,21 @@ func (m Compound) Score(ctx context.Context, j Judge, c Case) (Result, error) {
 		}
 	}
 	if lastParseErr != nil {
-		return Result{Metric: m.Name(), Latency: time.Since(start), Tokens: totalTokens}, fmt.Errorf("compound: parse response: %w", lastParseErr)
+		return Result{
+			Metric:           m.Name(),
+			Latency:          time.Since(start),
+			Tokens:           totalTokens,
+			PromptTokens:     totalPromptTokens,
+			CompletionTokens: totalCompletionTokens,
+		}, fmt.Errorf("compound: parse response: %w", lastParseErr)
 	}
-	return Result{Metric: m.Name(), Latency: time.Since(start), Tokens: totalTokens}, errors.New("compound: exhausted retry budget")
+	return Result{
+		Metric:           m.Name(),
+		Latency:          time.Since(start),
+		Tokens:           totalTokens,
+		PromptTokens:     totalPromptTokens,
+		CompletionTokens: totalCompletionTokens,
+	}, errors.New("compound: exhausted retry budget")
 }
 
 func validateDimensions(input []Dimension) ([]Dimension, error) {
@@ -166,7 +188,7 @@ func parseCompoundDimensions(content string, dimensions []Dimension) ([]Dimensio
 	return results, nil
 }
 
-func buildCompoundResult(metric string, dimensions []DimensionResult, latency time.Duration, tokens int) Result {
+func buildCompoundResult(metric string, dimensions []DimensionResult, latency time.Duration, tokens int, promptTokens int, completionTokens int) Result {
 	var sum float64
 	allPassed := true
 	parts := make([]string, 0, len(dimensions))
@@ -182,12 +204,14 @@ func buildCompoundResult(metric string, dimensions []DimensionResult, latency ti
 	}
 
 	return Result{
-		Score:      sum / float64(len(dimensions)),
-		Reason:     strings.Join(parts, " "),
-		Passed:     allPassed,
-		Metric:     metric,
-		Latency:    latency,
-		Tokens:     tokens,
-		Dimensions: dimensions,
+		Score:            sum / float64(len(dimensions)),
+		Reason:           strings.Join(parts, " "),
+		Passed:           allPassed,
+		Metric:           metric,
+		Latency:          latency,
+		Tokens:           tokens,
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		Dimensions:       dimensions,
 	}
 }

--- a/compound_test.go
+++ b/compound_test.go
@@ -7,9 +7,11 @@ import (
 )
 
 type rawSequenceJudge struct {
-	responses []string
-	calls     int
-	prompts   []string
+	responses        []string
+	calls            int
+	prompts          []string
+	promptTokens     []int
+	completionTokens []int
 }
 
 func (j *rawSequenceJudge) Evaluate(ctx context.Context, prompt string) (JudgeResponse, error) {
@@ -26,7 +28,20 @@ func (j *rawSequenceJudge) EvaluateRaw(ctx context.Context, prompt string) (RawJ
 		idx = len(j.responses) - 1
 	}
 	j.calls++
-	return RawJudgeResponse{Content: j.responses[idx], Tokens: 10}, nil
+	promptTokens := 3
+	if idx < len(j.promptTokens) {
+		promptTokens = j.promptTokens[idx]
+	}
+	completionTokens := 7
+	if idx < len(j.completionTokens) {
+		completionTokens = j.completionTokens[idx]
+	}
+	return RawJudgeResponse{
+		Content:          j.responses[idx],
+		Tokens:           promptTokens + completionTokens,
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+	}, nil
 }
 
 func TestCompound_AllPass(t *testing.T) {
@@ -202,6 +217,9 @@ func TestCompound_RetryOnceOnParseFailure(t *testing.T) {
 	}
 	if len(j.prompts) != 2 {
 		t.Fatalf("expected 2 prompts, got %d", len(j.prompts))
+	}
+	if r.Tokens != 20 || r.PromptTokens != 6 || r.CompletionTokens != 14 {
+		t.Fatalf("unexpected token aggregation: %+v", r)
 	}
 }
 

--- a/eval.go
+++ b/eval.go
@@ -16,10 +16,11 @@ const EnvVar = "GOEVAL"
 // Runner is safe for concurrent use so one instance can be shared across
 // parallel subtests and benchmarks.
 type Runner struct {
-	judge   Judge
-	timeout time.Duration
-	sink    ResultSink
-	sinkMu  sync.Mutex
+	judge      Judge
+	timeout    time.Duration
+	sink       ResultSink
+	caseFilter func(Case) bool
+	sinkMu     sync.Mutex
 }
 
 // Option configures a Runner at construction time.
@@ -29,6 +30,15 @@ type Option func(*Runner)
 func WithTimeout(d time.Duration) Option {
 	return func(r *Runner) {
 		r.timeout = d
+	}
+}
+
+// WithCaseFilter skips cases for which pred returns false.
+//
+// A nil predicate leaves Runner behavior unchanged.
+func WithCaseFilter(pred func(Case) bool) Option {
+	return func(r *Runner) {
+		r.caseFilter = pred
 	}
 }
 
@@ -46,7 +56,8 @@ func NewRunner(j Judge, opts ...Option) *Runner {
 
 // Run executes one metric against one case and asserts via tb.
 //
-// If GOEVAL is unset, the evaluation is skipped. Metric errors are fatal.
+// If GOEVAL is unset or the case filter excludes the case, the evaluation is
+// skipped. Metric errors are fatal.
 // Low scores are test errors but do not stop the test. The resulting Result
 // is returned in all cases so callers can chain their own assertions.
 func (r *Runner) Run(tb testing.TB, m Metric, c Case) Result {
@@ -54,6 +65,10 @@ func (r *Runner) Run(tb testing.TB, m Metric, c Case) Result {
 
 	if os.Getenv(EnvVar) == "" {
 		tb.Skip("eval skipped, set " + EnvVar + "=1 to run")
+		return Result{}
+	}
+	if r.caseFilter != nil && !r.caseFilter(c) {
+		tb.Skip("eval skipped by case filter")
 		return Result{}
 	}
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -148,7 +148,9 @@ func TestRunner_WithCaseFilterSkipsUnmatchedCase(t *testing.T) {
 	if metric.calls != 0 {
 		t.Fatalf("expected skipped case not to call metric, got %d calls", metric.calls)
 	}
-	if got.Score != 0 || got.Passed || got.Metric != "" || got.Reason != "" || got.Tokens != 0 || got.Metadata != nil {
+	if got.Score != 0 || got.Passed || got.Metric != "" || got.Reason != "" ||
+		got.Tokens != 0 || got.PromptTokens != 0 || got.CompletionTokens != 0 ||
+		got.Metadata != nil {
 		t.Fatalf("expected zero result for skipped case, got %+v", got)
 	}
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -17,11 +18,15 @@ type recordingTB struct {
 	logs        []string
 	errMsgs     []string
 	fatalMsgs   []string
+	skipMsgs    []string
 }
 
-func (r *recordingTB) Helper()          { r.helperCalls++ }
-func (r *recordingTB) Skip(args ...any) { r.skipped = true }
-func (r *recordingTB) SkipNow()         { r.skipped = true }
+func (r *recordingTB) Helper() { r.helperCalls++ }
+func (r *recordingTB) Skip(args ...any) {
+	r.skipped = true
+	r.skipMsgs = append(r.skipMsgs, fmt.Sprint(args...))
+}
+func (r *recordingTB) SkipNow() { r.skipped = true }
 func (r *recordingTB) Errorf(format string, args ...any) {
 	r.errored = true
 	r.errMsgs = append(r.errMsgs, format)
@@ -117,6 +122,59 @@ func TestRunner_WithTimeoutAppliesContext(t *testing.T) {
 
 	if !gotDeadline {
 		t.Fatalf("expected metric to receive a context with deadline")
+	}
+}
+
+func TestRunner_WithCaseFilterSkipsUnmatchedCase(t *testing.T) {
+	t.Setenv(EnvVar, "1")
+
+	metric := &countingMetric{
+		name:   "X",
+		result: Result{Score: 1, Passed: true, Metric: "X"},
+	}
+	tb := &recordingTB{}
+	r := NewRunner(&MockJudge{}, WithCaseFilter(func(c Case) bool {
+		return c.Metadata["tier"] == "critical"
+	}))
+
+	got := r.Run(tb, metric, Case{Metadata: map[string]any{"tier": "standard"}})
+
+	if !tb.skipped {
+		t.Fatalf("expected case filter to skip")
+	}
+	if len(tb.skipMsgs) != 1 || tb.skipMsgs[0] != "eval skipped by case filter" {
+		t.Fatalf("unexpected skip messages: %v", tb.skipMsgs)
+	}
+	if metric.calls != 0 {
+		t.Fatalf("expected skipped case not to call metric, got %d calls", metric.calls)
+	}
+	if got.Score != 0 || got.Passed || got.Metric != "" || got.Reason != "" || got.Tokens != 0 || got.Metadata != nil {
+		t.Fatalf("expected zero result for skipped case, got %+v", got)
+	}
+}
+
+func TestRunner_WithCaseFilterRunsMatchedCase(t *testing.T) {
+	t.Setenv(EnvVar, "1")
+
+	metric := &countingMetric{
+		name:   "X",
+		result: Result{Score: 1, Passed: true, Metric: "X"},
+	}
+	tb := &recordingTB{}
+	r := NewRunner(&MockJudge{}, WithCaseFilter(func(c Case) bool {
+		return c.Metadata["tier"] == "critical"
+	}))
+
+	got := r.Run(tb, metric, Case{Metadata: map[string]any{"tier": "critical"}})
+
+	if tb.skipped {
+		t.Fatalf("did not expect matched case to skip")
+	}
+	if metric.calls != 1 {
+		t.Fatalf("expected metric to run once, got %d calls", metric.calls)
+	}
+	if !got.Passed {
+		t.Fatalf("expected passing result, got %+v", got)
 	}
 }
 

--- a/judge.go
+++ b/judge.go
@@ -23,13 +23,17 @@ type RawJudge interface {
 // The Judge is responsible for parsing a model response such as
 // `{"score": 0.82, "reason": "..."}` into this struct.
 type JudgeResponse struct {
-	Score  float64
-	Reason string
-	Tokens int
+	Score            float64
+	Reason           string
+	Tokens           int
+	PromptTokens     int
+	CompletionTokens int
 }
 
 // RawJudgeResponse is the raw model output for an evaluation prompt.
 type RawJudgeResponse struct {
-	Content string
-	Tokens  int
+	Content          string
+	Tokens           int
+	PromptTokens     int
+	CompletionTokens int
 }

--- a/judge_mock_test.go
+++ b/judge_mock_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestMockJudge_ReturnsConfiguredResponse(t *testing.T) {
 	mj := &MockJudge{
-		Response: JudgeResponse{Score: 0.42, Reason: "canned", Tokens: 7},
+		Response: JudgeResponse{Score: 0.42, Reason: "canned", Tokens: 7, PromptTokens: 3, CompletionTokens: 4},
 	}
 
 	resp, err := mj.Evaluate(context.Background(), "prompt")
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
-	if resp.Score != 0.42 || resp.Reason != "canned" || resp.Tokens != 7 {
+	if resp.Score != 0.42 || resp.Reason != "canned" || resp.Tokens != 7 || resp.PromptTokens != 3 || resp.CompletionTokens != 4 {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
 	if mj.Calls() != 1 {

--- a/judge_test.go
+++ b/judge_test.go
@@ -13,14 +13,14 @@ func (f fnJudge) Evaluate(ctx context.Context, p string) (JudgeResponse, error) 
 
 func TestJudge_InterfaceSatisfied(t *testing.T) {
 	var j Judge = fnJudge(func(ctx context.Context, p string) (JudgeResponse, error) {
-		return JudgeResponse{Score: 0.5, Reason: "test", Tokens: 10}, nil
+		return JudgeResponse{Score: 0.5, Reason: "test", Tokens: 10, PromptTokens: 4, CompletionTokens: 6}, nil
 	})
 
 	resp, err := j.Evaluate(context.Background(), "anything")
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
-	if resp.Score != 0.5 || resp.Reason != "test" || resp.Tokens != 10 {
+	if resp.Score != 0.5 || resp.Reason != "test" || resp.Tokens != 10 || resp.PromptTokens != 4 || resp.CompletionTokens != 6 {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
 }

--- a/metric.go
+++ b/metric.go
@@ -26,13 +26,15 @@ type DimensionResult struct {
 
 // Result is what a Metric returns after scoring a Case.
 type Result struct {
-	Score      float64
-	Reason     string
-	Passed     bool
-	Metric     string
-	Latency    time.Duration
-	Tokens     int
-	Dimensions []DimensionResult
-	Metadata   map[string]any
-	_          struct{}
+	Score            float64
+	Reason           string
+	Passed           bool
+	Metric           string
+	Latency          time.Duration
+	Tokens           int
+	PromptTokens     int
+	CompletionTokens int
+	Dimensions       []DimensionResult
+	Metadata         map[string]any
+	_                struct{}
 }

--- a/metric_support.go
+++ b/metric_support.go
@@ -67,11 +67,13 @@ func runPromptMetric(
 	}
 
 	return Result{
-		Score:   resp.Score,
-		Reason:  resp.Reason,
-		Passed:  resp.Score >= threshold,
-		Metric:  metricName,
-		Latency: latency,
-		Tokens:  resp.Tokens,
+		Score:            resp.Score,
+		Reason:           resp.Reason,
+		Passed:           resp.Score >= threshold,
+		Metric:           metricName,
+		Latency:          latency,
+		Tokens:           resp.Tokens,
+		PromptTokens:     resp.PromptTokens,
+		CompletionTokens: resp.CompletionTokens,
 	}, nil
 }

--- a/metric_test.go
+++ b/metric_test.go
@@ -31,14 +31,34 @@ func TestMetric_InterfaceSatisfied(t *testing.T) {
 
 func TestResult_FieldsAccessible(t *testing.T) {
 	r := Result{
-		Score:   0.75,
-		Reason:  "ok",
-		Passed:  true,
-		Metric:  "Faithfulness",
-		Latency: 100 * time.Millisecond,
-		Tokens:  42,
+		Score:            0.75,
+		Reason:           "ok",
+		Passed:           true,
+		Metric:           "Faithfulness",
+		Latency:          100 * time.Millisecond,
+		Tokens:           42,
+		PromptTokens:     20,
+		CompletionTokens: 22,
 	}
-	if r.Score != 0.75 || r.Tokens != 42 || r.Latency != 100*time.Millisecond {
+	if r.Score != 0.75 || r.Tokens != 42 || r.PromptTokens != 20 || r.CompletionTokens != 22 || r.Latency != 100*time.Millisecond {
 		t.Fatalf("unexpected Result: %+v", r)
+	}
+}
+
+func TestRunPromptMetricCopiesTokenSplit(t *testing.T) {
+	j := &MockJudge{Response: JudgeResponse{
+		Score:            0.8,
+		Reason:           "ok",
+		Tokens:           10,
+		PromptTokens:     4,
+		CompletionTokens: 6,
+	}}
+
+	r, err := runPromptMetric(context.Background(), j, "prompt", "faithfulness", "Faithfulness", 0.7)
+	if err != nil {
+		t.Fatalf("runPromptMetric: %v", err)
+	}
+	if r.Tokens != 10 || r.PromptTokens != 4 || r.CompletionTokens != 6 {
+		t.Fatalf("unexpected token fields: %+v", r)
 	}
 }

--- a/precheck.go
+++ b/precheck.go
@@ -44,12 +44,14 @@ func (m Precheck) Score(ctx context.Context, j Judge, c Case) (Result, error) {
 
 	if !preResult.Passed {
 		return Result{
-			Score:   0,
-			Passed:  false,
-			Metric:  m.Main.Name(),
-			Reason:  fmt.Sprintf("precheck<%s> failed: %s", m.Pre.Name(), preResult.Reason),
-			Latency: preResult.Latency,
-			Tokens:  preResult.Tokens,
+			Score:            0,
+			Passed:           false,
+			Metric:           m.Main.Name(),
+			Reason:           fmt.Sprintf("precheck<%s> failed: %s", m.Pre.Name(), preResult.Reason),
+			Latency:          preResult.Latency,
+			Tokens:           preResult.Tokens,
+			PromptTokens:     preResult.PromptTokens,
+			CompletionTokens: preResult.CompletionTokens,
 		}, nil
 	}
 
@@ -58,6 +60,8 @@ func (m Precheck) Score(ctx context.Context, j Judge, c Case) (Result, error) {
 		mainResult.Metric = m.Main.Name()
 	}
 	mainResult.Tokens += preResult.Tokens
+	mainResult.PromptTokens += preResult.PromptTokens
+	mainResult.CompletionTokens += preResult.CompletionTokens
 	mainResult.Latency += preResult.Latency
 	if err != nil {
 		return mainResult, fmt.Errorf("precheck: main metric %s: %w", m.Main.Name(), err)

--- a/precheck_test.go
+++ b/precheck_test.go
@@ -27,12 +27,14 @@ func TestPrecheck_FailedPrecheckSkipsMain(t *testing.T) {
 	pre := &countingMetric{
 		name: "Contains",
 		result: Result{
-			Score:   0,
-			Passed:  false,
-			Metric:  "Contains",
-			Reason:  "missing city",
-			Tokens:  2,
-			Latency: 5 * time.Millisecond,
+			Score:            0,
+			Passed:           false,
+			Metric:           "Contains",
+			Reason:           "missing city",
+			Tokens:           2,
+			PromptTokens:     1,
+			CompletionTokens: 1,
+			Latency:          5 * time.Millisecond,
 		},
 	}
 	main := &countingMetric{
@@ -59,16 +61,19 @@ func TestPrecheck_FailedPrecheckSkipsMain(t *testing.T) {
 	if r.Tokens != 2 || r.Latency != 5*time.Millisecond {
 		t.Fatalf("unexpected metadata aggregation: tokens=%d latency=%s", r.Tokens, r.Latency)
 	}
+	if r.PromptTokens != 1 || r.CompletionTokens != 1 {
+		t.Fatalf("unexpected token split: prompt=%d completion=%d", r.PromptTokens, r.CompletionTokens)
+	}
 }
 
 func TestPrecheck_PassingPrecheckRunsMain(t *testing.T) {
 	pre := &countingMetric{
 		name:   "Contains",
-		result: Result{Score: 1, Passed: true, Metric: "Contains", Tokens: 2, Latency: 5 * time.Millisecond},
+		result: Result{Score: 1, Passed: true, Metric: "Contains", Tokens: 2, PromptTokens: 1, CompletionTokens: 1, Latency: 5 * time.Millisecond},
 	}
 	main := &countingMetric{
 		name:   "Faithfulness",
-		result: Result{Score: 0.9, Passed: true, Metric: "Faithfulness", Tokens: 10, Latency: 20 * time.Millisecond},
+		result: Result{Score: 0.9, Passed: true, Metric: "Faithfulness", Tokens: 10, PromptTokens: 4, CompletionTokens: 6, Latency: 20 * time.Millisecond},
 	}
 
 	r, err := (Precheck{Pre: pre, Main: main}).Score(context.Background(), nil, Case{})
@@ -83,6 +88,9 @@ func TestPrecheck_PassingPrecheckRunsMain(t *testing.T) {
 	}
 	if r.Tokens != 12 {
 		t.Fatalf("unexpected token aggregation: got %d", r.Tokens)
+	}
+	if r.PromptTokens != 5 || r.CompletionTokens != 7 {
+		t.Fatalf("unexpected token split aggregation: prompt=%d completion=%d", r.PromptTokens, r.CompletionTokens)
 	}
 	if r.Latency != 25*time.Millisecond {
 		t.Fatalf("unexpected latency aggregation: got %s", r.Latency)

--- a/result_sink.go
+++ b/result_sink.go
@@ -14,16 +14,18 @@ const ResultsDirEnvVar = "GOEVAL_RESULTS_DIR"
 
 // RunResult is the serialized form of a metric run.
 type RunResult struct {
-	Timestamp  string            `json:"timestamp"`
-	TestName   string            `json:"test_name"`
-	Metric     string            `json:"metric"`
-	Score      float64           `json:"score"`
-	Passed     bool              `json:"passed"`
-	Reason     string            `json:"reason"`
-	Tokens     int               `json:"tokens"`
-	LatencyNS  int64             `json:"latency_ns"`
-	Dimensions []DimensionResult `json:"dimensions,omitempty"`
-	Metadata   map[string]any    `json:"metadata,omitempty"`
+	Timestamp        string            `json:"timestamp"`
+	TestName         string            `json:"test_name"`
+	Metric           string            `json:"metric"`
+	Score            float64           `json:"score"`
+	Passed           bool              `json:"passed"`
+	Reason           string            `json:"reason"`
+	Tokens           int               `json:"tokens"`
+	PromptTokens     int               `json:"prompt_tokens,omitempty"`
+	CompletionTokens int               `json:"completion_tokens,omitempty"`
+	LatencyNS        int64             `json:"latency_ns"`
+	Dimensions       []DimensionResult `json:"dimensions,omitempty"`
+	Metadata         map[string]any    `json:"metadata,omitempty"`
 }
 
 // ResultSink receives per-run serialized results.
@@ -85,15 +87,17 @@ func (s *jsonlFileSink) Write(result RunResult) error {
 
 func newRunResult(tbName string, result Result) RunResult {
 	return RunResult{
-		Timestamp:  time.Now().UTC().Format(time.RFC3339Nano),
-		TestName:   tbName,
-		Metric:     result.Metric,
-		Score:      result.Score,
-		Passed:     result.Passed,
-		Reason:     result.Reason,
-		Tokens:     result.Tokens,
-		LatencyNS:  int64(result.Latency),
-		Dimensions: result.Dimensions,
-		Metadata:   result.Metadata,
+		Timestamp:        time.Now().UTC().Format(time.RFC3339Nano),
+		TestName:         tbName,
+		Metric:           result.Metric,
+		Score:            result.Score,
+		Passed:           result.Passed,
+		Reason:           result.Reason,
+		Tokens:           result.Tokens,
+		PromptTokens:     result.PromptTokens,
+		CompletionTokens: result.CompletionTokens,
+		LatencyNS:        int64(result.Latency),
+		Dimensions:       result.Dimensions,
+		Metadata:         result.Metadata,
 	}
 }

--- a/result_sink_test.go
+++ b/result_sink_test.go
@@ -87,10 +87,13 @@ func TestDefaultResultSink_WritesJSONL(t *testing.T) {
 		t.Fatalf("expected non-nil sink")
 	}
 	if err := sink.Write(RunResult{
-		TestName: "t",
-		Metric:   "m",
-		Score:    1,
-		Metadata: map[string]any{"suite": "conversation", "user_language": "spanish"},
+		TestName:         "t",
+		Metric:           "m",
+		Score:            1,
+		Tokens:           11,
+		PromptTokens:     4,
+		CompletionTokens: 7,
+		Metadata:         map[string]any{"suite": "conversation", "user_language": "spanish"},
 	}); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
@@ -114,6 +117,9 @@ func TestDefaultResultSink_WritesJSONL(t *testing.T) {
 	}
 	if got.Metadata["suite"] != "conversation" || got.Metadata["user_language"] != "spanish" {
 		t.Fatalf("unexpected metadata: %+v", got.Metadata)
+	}
+	if got.Tokens != 11 || got.PromptTokens != 4 || got.CompletionTokens != 7 {
+		t.Fatalf("unexpected token fields: %+v", got)
 	}
 }
 
@@ -160,11 +166,14 @@ func TestJSONLFileSink_ConcurrentWrites(t *testing.T) {
 
 func TestNewRunResult(t *testing.T) {
 	rr := newRunResult("test/name", Result{
-		Score:    0.5,
-		Passed:   true,
-		Metric:   "MetricX",
-		Reason:   "ok",
-		Metadata: map[string]any{"trace_id": "abc"},
+		Score:            0.5,
+		Passed:           true,
+		Metric:           "MetricX",
+		Reason:           "ok",
+		Tokens:           9,
+		PromptTokens:     3,
+		CompletionTokens: 6,
+		Metadata:         map[string]any{"trace_id": "abc"},
 	})
 	if rr.TestName != "test/name" || rr.Metric != "MetricX" {
 		t.Fatalf("unexpected run result: %+v", rr)
@@ -174,6 +183,9 @@ func TestNewRunResult(t *testing.T) {
 	}
 	if rr.Metadata["trace_id"] != "abc" {
 		t.Fatalf("unexpected metadata: %+v", rr.Metadata)
+	}
+	if rr.Tokens != 9 || rr.PromptTokens != 3 || rr.CompletionTokens != 6 {
+		t.Fatalf("unexpected token fields: %+v", rr)
 	}
 }
 


### PR DESCRIPTION
Refs #8.

Summary:
- add PromptTokens and CompletionTokens across JudgeResponse, RawJudgeResponse, Result, RunResult, sinks, Compound, Precheck, and prompt metrics
- propagate OpenAI usage prompt/completion token counts, including parse-retry totals
- add WithCaseFilter plus metadata conventions for flow/tier/dataset
- update README, AGENTS, and CHANGELOG

Verification:
- go test ./...
- go test ./... in adapters/openai
- go test -race ./...
- go test -race ./... in adapters/openai
- golangci-lint run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds split token tracking (prompt vs completion) across judges, metrics, and JSONL output, and adds case filtering and metadata conventions for targeted eval reporting. Addresses #8 by laying the groundwork for richer usage reporting and selective runs.

- **New Features**
  - Added `PromptTokens` and `CompletionTokens` to `JudgeResponse`, `RawJudgeResponse`, `Result`, and `RunResult`; JSONL now includes `prompt_tokens` and `completion_tokens`.
  - `adapters/openai`: propagates OpenAI usage prompt/completion counts and aggregates them across parse-retry attempts.
  - `Precheck` and `Compound`: aggregate split tokens across steps and retries.
  - `WithCaseFilter` runner option to skip cases (e.g., run only `tier=critical`).
  - Documented `Case.Metadata` conventions: `flow`, `tier`, `dataset`; `Runner` continues copying metadata into results.

<sup>Written for commit 6ffdf5e7ed7c406997897577d98a8c73d9e8e411. Summary will update on new commits. <a href="https://cubic.dev/pr/igcodinap/go-eval/pull/10?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token breakdown tracking: judge responses and evaluation results now report prompt and completion token counts separately.
  * Case filtering: new option to skip test cases based on metadata or custom predicates.

* **Documentation**
  * Updated specs and README for token fields and JSONL output (token fields omitted when zero).
  * Added usage examples for case filtering and metadata handling conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->