### PR TITLE
Add JSONL regression comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split token counts (`PromptTokens`, `CompletionTokens`) on judge responses, results, and JSONL sink rows
 - `WithCaseFilter` runner option for skipping cases by metadata or custom predicates
 - `authoring-go-eval-suites` agent skill and Claude `/eval` command for designing, running, and reviewing eval suites
+- `compare` package for baseline-vs-current JSONL result regression diffs
 
 ## [v0.2.0] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ When `GOEVAL_RESULTS_DIR` is set, `DefaultResultSink` writes
 `metadata`. `Runner` copies `Case.Metadata` into the run result unless a metric
 sets `Result.Metadata` explicitly.
 
+Compare a baseline and current result file with the `compare` package:
+
+```go
+report, err := compare.CompareFiles("old/results.jsonl", "new/results.jsonl")
+if err != nil {
+	// handle malformed JSONL or file errors
+}
+```
+
+Rows are matched by `test_name` and `metric` by default. Use
+`compare.Options.Identity` when a separate case id is stored in metadata.
+Reports include added, missing, improved, regressed, and unchanged entries, with
+score, pass/fail, token, latency, and Compound dimension deltas.
+
 Use `WithCaseFilter` to run a selected slice of cases, for example a
 critical-only CI path:
 

--- a/compare/compare.go
+++ b/compare/compare.go
@@ -1,0 +1,433 @@
+package compare
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+
+	eval "github.com/igcodinap/go-eval"
+)
+
+const maxJSONLLineSize = 10 * 1024 * 1024
+
+// Status describes how a result changed from baseline to current.
+type Status string
+
+const (
+	StatusUnchanged Status = "unchanged"
+	StatusImproved  Status = "improved"
+	StatusRegressed Status = "regressed"
+	StatusAdded     Status = "added"
+	StatusMissing   Status = "missing"
+)
+
+// PassChange describes a pass/fail transition.
+type PassChange string
+
+const (
+	PassUnchanged    PassChange = "unchanged"
+	PassFailedToPass PassChange = "failed_to_passed"
+	PassPassedToFail PassChange = "passed_to_failed"
+)
+
+// Identity is the key used to match baseline and current rows.
+type Identity struct {
+	TestName string
+	CaseName string
+	Metric   string
+}
+
+// IdentityFunc builds a comparison identity for a result row.
+type IdentityFunc func(eval.RunResult) Identity
+
+// Options configures comparison behavior.
+type Options struct {
+	// Identity overrides the default test-name and metric identity.
+	Identity IdentityFunc
+
+	// ScoreTolerance treats score deltas within this absolute value as
+	// unchanged for status classification. The raw delta is still reported.
+	ScoreTolerance float64
+}
+
+// Report is the deterministic comparison output.
+type Report struct {
+	Summary Summary
+	Entries []Entry
+}
+
+// Summary counts entries by status.
+type Summary struct {
+	Total     int
+	Added     int
+	Missing   int
+	Improved  int
+	Regressed int
+	Unchanged int
+}
+
+// Entry compares one matched result row.
+//
+// Occurrence is zero unless multiple rows share the same identity in a file, in
+// which case rows are compared in file order.
+type Entry struct {
+	Identity    Identity
+	Occurrence  int
+	Status      Status
+	Baseline    eval.RunResult
+	Current     eval.RunResult
+	HasBaseline bool
+	HasCurrent  bool
+	Delta       Delta
+	Dimensions  []DimensionEntry
+}
+
+// Delta captures numeric and pass/fail changes for matched rows.
+type Delta struct {
+	Score            float64
+	Tokens           int
+	PromptTokens     int
+	CompletionTokens int
+	LatencyNS        int64
+	Pass             PassChange
+}
+
+// DimensionEntry compares one Compound dimension.
+type DimensionEntry struct {
+	Name        string
+	Status      Status
+	Baseline    eval.DimensionResult
+	Current     eval.DimensionResult
+	HasBaseline bool
+	HasCurrent  bool
+	Delta       DimensionDelta
+}
+
+// DimensionDelta captures numeric and pass/fail changes for a dimension.
+type DimensionDelta struct {
+	Score     float64
+	Threshold float64
+	Pass      PassChange
+}
+
+// DefaultIdentity matches rows by test name and metric.
+func DefaultIdentity(result eval.RunResult) Identity {
+	return Identity{
+		TestName: result.TestName,
+		Metric:   result.Metric,
+	}
+}
+
+// ReadJSONL reads RunResult rows from a JSONL stream.
+func ReadJSONL(r io.Reader) ([]eval.RunResult, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 1024), maxJSONLLineSize)
+
+	var results []eval.RunResult
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var result eval.RunResult
+		if err := json.Unmarshal(line, &result); err != nil {
+			return nil, fmt.Errorf("jsonl line %d: %w", lineNo, err)
+		}
+		results = append(results, result)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read jsonl: %w", err)
+	}
+	return results, nil
+}
+
+// ReadJSONLFile reads RunResult rows from a results.jsonl file.
+func ReadJSONLFile(path string) ([]eval.RunResult, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	results, readErr := ReadJSONL(f)
+	closeErr := f.Close()
+	if readErr != nil && closeErr != nil {
+		return nil, errors.Join(readErr, closeErr)
+	}
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return results, nil
+}
+
+// CompareFiles reads and compares two JSONL result files.
+func CompareFiles(baselinePath string, currentPath string) (Report, error) {
+	baseline, err := ReadJSONLFile(baselinePath)
+	if err != nil {
+		return Report{}, fmt.Errorf("read baseline %q: %w", baselinePath, err)
+	}
+	current, err := ReadJSONLFile(currentPath)
+	if err != nil {
+		return Report{}, fmt.Errorf("read current %q: %w", currentPath, err)
+	}
+	return Compare(baseline, current), nil
+}
+
+// Compare compares baseline and current result rows using default options.
+func Compare(baseline []eval.RunResult, current []eval.RunResult) Report {
+	return CompareWithOptions(baseline, current, Options{})
+}
+
+// CompareWithOptions compares baseline and current result rows.
+func CompareWithOptions(baseline []eval.RunResult, current []eval.RunResult, opts Options) Report {
+	identify := opts.Identity
+	if identify == nil {
+		identify = DefaultIdentity
+	}
+	tolerance := math.Abs(opts.ScoreTolerance)
+
+	baselineByID := indexResults(baseline, identify)
+	currentByID := indexResults(current, identify)
+	ids := sortedIdentities(baselineByID, currentByID)
+
+	var report Report
+	for _, id := range ids {
+		baselineRows := baselineByID[id]
+		currentRows := currentByID[id]
+		maxLen := max(len(baselineRows), len(currentRows))
+		for i := 0; i < maxLen; i++ {
+			entry := Entry{
+				Identity:   id,
+				Occurrence: i,
+			}
+
+			switch {
+			case i >= len(baselineRows):
+				entry.Status = StatusAdded
+				entry.Current = currentRows[i]
+				entry.HasCurrent = true
+			case i >= len(currentRows):
+				entry.Status = StatusMissing
+				entry.Baseline = baselineRows[i]
+				entry.HasBaseline = true
+			default:
+				entry.Baseline = baselineRows[i]
+				entry.Current = currentRows[i]
+				entry.HasBaseline = true
+				entry.HasCurrent = true
+				entry.Delta = compareDelta(entry.Baseline, entry.Current)
+				entry.Dimensions = compareDimensions(entry.Baseline.Dimensions, entry.Current.Dimensions, tolerance)
+				entry.Status = classify(entry.Baseline, entry.Current, entry.Delta, entry.Dimensions, tolerance)
+			}
+
+			report.Entries = append(report.Entries, entry)
+			report.Summary.add(entry.Status)
+		}
+	}
+
+	return report
+}
+
+func indexResults(results []eval.RunResult, identify IdentityFunc) map[Identity][]eval.RunResult {
+	indexed := make(map[Identity][]eval.RunResult)
+	for _, result := range results {
+		id := identify(result)
+		indexed[id] = append(indexed[id], result)
+	}
+	return indexed
+}
+
+func sortedIdentities(left map[Identity][]eval.RunResult, right map[Identity][]eval.RunResult) []Identity {
+	seen := make(map[Identity]struct{}, len(left)+len(right))
+	for id := range left {
+		seen[id] = struct{}{}
+	}
+	for id := range right {
+		seen[id] = struct{}{}
+	}
+
+	ids := make([]Identity, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i int, j int) bool {
+		return compareIdentity(ids[i], ids[j]) < 0
+	})
+	return ids
+}
+
+func compareIdentity(left Identity, right Identity) int {
+	if left.TestName != right.TestName {
+		return stringsCompare(left.TestName, right.TestName)
+	}
+	if left.CaseName != right.CaseName {
+		return stringsCompare(left.CaseName, right.CaseName)
+	}
+	return stringsCompare(left.Metric, right.Metric)
+}
+
+func stringsCompare(left string, right string) int {
+	switch {
+	case left < right:
+		return -1
+	case left > right:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareDelta(baseline eval.RunResult, current eval.RunResult) Delta {
+	return Delta{
+		Score:            current.Score - baseline.Score,
+		Tokens:           current.Tokens - baseline.Tokens,
+		PromptTokens:     current.PromptTokens - baseline.PromptTokens,
+		CompletionTokens: current.CompletionTokens - baseline.CompletionTokens,
+		LatencyNS:        current.LatencyNS - baseline.LatencyNS,
+		Pass:             comparePass(baseline.Passed, current.Passed),
+	}
+}
+
+func comparePass(baseline bool, current bool) PassChange {
+	switch {
+	case !baseline && current:
+		return PassFailedToPass
+	case baseline && !current:
+		return PassPassedToFail
+	default:
+		return PassUnchanged
+	}
+}
+
+func compareDimensions(baseline []eval.DimensionResult, current []eval.DimensionResult, tolerance float64) []DimensionEntry {
+	baselineByName := indexDimensions(baseline)
+	currentByName := indexDimensions(current)
+	names := sortedDimensionNames(baselineByName, currentByName)
+
+	entries := make([]DimensionEntry, 0, len(names))
+	for _, name := range names {
+		entry := DimensionEntry{Name: name}
+		baselineDimension, hasBaseline := baselineByName[name]
+		currentDimension, hasCurrent := currentByName[name]
+		entry.Baseline = baselineDimension
+		entry.Current = currentDimension
+		entry.HasBaseline = hasBaseline
+		entry.HasCurrent = hasCurrent
+
+		switch {
+		case !hasBaseline:
+			entry.Status = StatusAdded
+		case !hasCurrent:
+			entry.Status = StatusMissing
+		default:
+			entry.Delta = DimensionDelta{
+				Score:     currentDimension.Score - baselineDimension.Score,
+				Threshold: currentDimension.Threshold - baselineDimension.Threshold,
+				Pass:      comparePass(baselineDimension.Passed, currentDimension.Passed),
+			}
+			entry.Status = classifyDimension(baselineDimension, currentDimension, entry.Delta, tolerance)
+		}
+
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func indexDimensions(dimensions []eval.DimensionResult) map[string]eval.DimensionResult {
+	indexed := make(map[string]eval.DimensionResult, len(dimensions))
+	for _, dimension := range dimensions {
+		indexed[dimension.Name] = dimension
+	}
+	return indexed
+}
+
+func sortedDimensionNames(left map[string]eval.DimensionResult, right map[string]eval.DimensionResult) []string {
+	seen := make(map[string]struct{}, len(left)+len(right))
+	for name := range left {
+		seen[name] = struct{}{}
+	}
+	for name := range right {
+		seen[name] = struct{}{}
+	}
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func classify(baseline eval.RunResult, current eval.RunResult, delta Delta, dimensions []DimensionEntry, tolerance float64) Status {
+	switch {
+	case baseline.Passed && !current.Passed:
+		return StatusRegressed
+	case !baseline.Passed && current.Passed:
+		return StatusImproved
+	}
+
+	hasImprovement := false
+	for _, dimension := range dimensions {
+		switch dimension.Status {
+		case StatusRegressed, StatusMissing:
+			return StatusRegressed
+		case StatusImproved:
+			hasImprovement = true
+		}
+	}
+	if hasImprovement {
+		if delta.Score < -tolerance {
+			return StatusRegressed
+		}
+		return StatusImproved
+	}
+	switch {
+	case delta.Score < -tolerance:
+		return StatusRegressed
+	case delta.Score > tolerance:
+		return StatusImproved
+	}
+	return StatusUnchanged
+}
+
+func classifyDimension(baseline eval.DimensionResult, current eval.DimensionResult, delta DimensionDelta, tolerance float64) Status {
+	switch {
+	case baseline.Passed && !current.Passed:
+		return StatusRegressed
+	case !baseline.Passed && current.Passed:
+		return StatusImproved
+	case delta.Score < -tolerance:
+		return StatusRegressed
+	case delta.Score > tolerance:
+		return StatusImproved
+	default:
+		return StatusUnchanged
+	}
+}
+
+func (s *Summary) add(status Status) {
+	s.Total++
+	switch status {
+	case StatusAdded:
+		s.Added++
+	case StatusMissing:
+		s.Missing++
+	case StatusImproved:
+		s.Improved++
+	case StatusRegressed:
+		s.Regressed++
+	case StatusUnchanged:
+		s.Unchanged++
+	}
+}

--- a/compare/compare_test.go
+++ b/compare/compare_test.go
@@ -1,0 +1,266 @@
+package compare
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	eval "github.com/igcodinap/go-eval"
+)
+
+func TestCompareReportsScorePassTokenAndLatencyDeltas(t *testing.T) {
+	baseline := []eval.RunResult{
+		{
+			TestName:         "TestEval/regress",
+			Metric:           "Faithfulness",
+			Score:            0.9,
+			Passed:           true,
+			Tokens:           10,
+			PromptTokens:     4,
+			CompletionTokens: 6,
+			LatencyNS:        100,
+		},
+		{
+			TestName:  "TestEval/improve",
+			Metric:    "Faithfulness",
+			Score:     0.4,
+			Passed:    false,
+			Tokens:    8,
+			LatencyNS: 200,
+		},
+	}
+	current := []eval.RunResult{
+		{
+			TestName:         "TestEval/regress",
+			Metric:           "Faithfulness",
+			Score:            0.7,
+			Passed:           true,
+			Tokens:           15,
+			PromptTokens:     5,
+			CompletionTokens: 10,
+			LatencyNS:        120,
+		},
+		{
+			TestName:  "TestEval/improve",
+			Metric:    "Faithfulness",
+			Score:     0.8,
+			Passed:    true,
+			Tokens:    7,
+			LatencyNS: 150,
+		},
+	}
+
+	report := Compare(baseline, current)
+
+	if report.Summary.Total != 2 || report.Summary.Improved != 1 || report.Summary.Regressed != 1 {
+		t.Fatalf("unexpected summary: %+v", report.Summary)
+	}
+
+	regressed := findEntry(t, report, "TestEval/regress", "", "Faithfulness")
+	if regressed.Status != StatusRegressed {
+		t.Fatalf("expected regressed status, got %q", regressed.Status)
+	}
+	assertFloat(t, regressed.Delta.Score, -0.2)
+	if regressed.Delta.Tokens != 5 ||
+		regressed.Delta.PromptTokens != 1 ||
+		regressed.Delta.CompletionTokens != 4 ||
+		regressed.Delta.LatencyNS != 20 {
+		t.Fatalf("unexpected regressed delta: %+v", regressed.Delta)
+	}
+	if regressed.Delta.Pass != PassUnchanged {
+		t.Fatalf("unexpected pass delta: %q", regressed.Delta.Pass)
+	}
+
+	improved := findEntry(t, report, "TestEval/improve", "", "Faithfulness")
+	if improved.Status != StatusImproved {
+		t.Fatalf("expected improved status, got %q", improved.Status)
+	}
+	assertFloat(t, improved.Delta.Score, 0.4)
+	if improved.Delta.Pass != PassFailedToPass {
+		t.Fatalf("unexpected pass delta: %q", improved.Delta.Pass)
+	}
+}
+
+func TestCompareRepresentsMissingAndAddedRowsDeterministically(t *testing.T) {
+	baseline := []eval.RunResult{
+		{TestName: "TestEval/a", Metric: "Faithfulness", Score: 0.8, Passed: true},
+		{TestName: "TestEval/c", Metric: "Faithfulness", Score: 0.8, Passed: true},
+	}
+	current := []eval.RunResult{
+		{TestName: "TestEval/b", Metric: "Faithfulness", Score: 0.8, Passed: true},
+		{TestName: "TestEval/c", Metric: "Faithfulness", Score: 0.8, Passed: true},
+	}
+
+	report := Compare(baseline, current)
+
+	if report.Summary.Total != 3 ||
+		report.Summary.Missing != 1 ||
+		report.Summary.Added != 1 ||
+		report.Summary.Unchanged != 1 {
+		t.Fatalf("unexpected summary: %+v", report.Summary)
+	}
+	want := []struct {
+		testName string
+		status   Status
+	}{
+		{"TestEval/a", StatusMissing},
+		{"TestEval/b", StatusAdded},
+		{"TestEval/c", StatusUnchanged},
+	}
+	if len(report.Entries) != len(want) {
+		t.Fatalf("expected %d entries, got %d", len(want), len(report.Entries))
+	}
+	for i, wantEntry := range want {
+		got := report.Entries[i]
+		if got.Identity.TestName != wantEntry.testName || got.Status != wantEntry.status {
+			t.Fatalf("entry %d: got %+v, want test=%q status=%q", i, got, wantEntry.testName, wantEntry.status)
+		}
+	}
+}
+
+func TestCompareWithOptionsUsesCaseIdentity(t *testing.T) {
+	baseline := []eval.RunResult{
+		{TestName: "TestEval", Metric: "Faithfulness", Score: 0.5, Passed: true, Metadata: map[string]any{"case_id": "b"}},
+		{TestName: "TestEval", Metric: "Faithfulness", Score: 0.8, Passed: true, Metadata: map[string]any{"case_id": "a"}},
+	}
+	current := []eval.RunResult{
+		{TestName: "TestEval", Metric: "Faithfulness", Score: 0.7, Passed: true, Metadata: map[string]any{"case_id": "a"}},
+		{TestName: "TestEval", Metric: "Faithfulness", Score: 0.6, Passed: true, Metadata: map[string]any{"case_id": "b"}},
+	}
+	identity := func(result eval.RunResult) Identity {
+		caseName, _ := result.Metadata["case_id"].(string)
+		return Identity{TestName: result.TestName, CaseName: caseName, Metric: result.Metric}
+	}
+
+	report := CompareWithOptions(baseline, current, Options{Identity: identity})
+
+	if len(report.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(report.Entries))
+	}
+	if report.Entries[0].Identity.CaseName != "a" || report.Entries[0].Status != StatusRegressed {
+		t.Fatalf("unexpected first entry: %+v", report.Entries[0])
+	}
+	if report.Entries[1].Identity.CaseName != "b" || report.Entries[1].Status != StatusImproved {
+		t.Fatalf("unexpected second entry: %+v", report.Entries[1])
+	}
+}
+
+func TestReadJSONLRejectsMalformedLine(t *testing.T) {
+	_, err := ReadJSONL(strings.NewReader(`{"test_name":"TestEval","metric":"Faithfulness"}` + "\n" + `{bad json}`))
+	if err == nil {
+		t.Fatalf("expected malformed JSONL error")
+	}
+	if !strings.Contains(err.Error(), "jsonl line 2") {
+		t.Fatalf("expected line number in error, got %v", err)
+	}
+}
+
+func TestCompareFilesReadsJSONLFiles(t *testing.T) {
+	dir := t.TempDir()
+	baselinePath := filepath.Join(dir, "baseline.jsonl")
+	currentPath := filepath.Join(dir, "current.jsonl")
+	if err := os.WriteFile(baselinePath, []byte(`{"test_name":"TestEval","metric":"Faithfulness","score":0.5,"passed":true}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile baseline: %v", err)
+	}
+	if err := os.WriteFile(currentPath, []byte(`{"test_name":"TestEval","metric":"Faithfulness","score":0.6,"passed":true}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile current: %v", err)
+	}
+
+	report, err := CompareFiles(baselinePath, currentPath)
+	if err != nil {
+		t.Fatalf("CompareFiles: %v", err)
+	}
+	entry := findEntry(t, report, "TestEval", "", "Faithfulness")
+	if entry.Status != StatusImproved {
+		t.Fatalf("expected improved entry, got %+v", entry)
+	}
+}
+
+func TestCompareIncludesCompoundDimensionDeltas(t *testing.T) {
+	baseline := []eval.RunResult{
+		{
+			TestName: "TestEval/compound",
+			Metric:   "Compound",
+			Score:    0.8,
+			Passed:   true,
+			Dimensions: []eval.DimensionResult{
+				{Name: "factuality", Score: 0.9, Threshold: 0.7, Passed: true},
+				{Name: "removed", Score: 0.8, Threshold: 0.7, Passed: true},
+				{Name: "style", Score: 0.7, Threshold: 0.7, Passed: true},
+			},
+		},
+	}
+	current := []eval.RunResult{
+		{
+			TestName: "TestEval/compound",
+			Metric:   "Compound",
+			Score:    0.8,
+			Passed:   true,
+			Dimensions: []eval.DimensionResult{
+				{Name: "added", Score: 0.9, Threshold: 0.7, Passed: true},
+				{Name: "factuality", Score: 0.6, Threshold: 0.75, Passed: false},
+				{Name: "style", Score: 0.8, Threshold: 0.7, Passed: true},
+			},
+		},
+	}
+
+	report := Compare(baseline, current)
+
+	entry := findEntry(t, report, "TestEval/compound", "", "Compound")
+	if entry.Status != StatusRegressed {
+		t.Fatalf("expected dimension regression to mark entry regressed, got %q", entry.Status)
+	}
+
+	factuality := findDimension(t, entry, "factuality")
+	if factuality.Status != StatusRegressed || factuality.Delta.Pass != PassPassedToFail {
+		t.Fatalf("unexpected factuality dimension: %+v", factuality)
+	}
+	assertFloat(t, factuality.Delta.Score, -0.3)
+	assertFloat(t, factuality.Delta.Threshold, 0.05)
+
+	style := findDimension(t, entry, "style")
+	if style.Status != StatusImproved {
+		t.Fatalf("unexpected style dimension: %+v", style)
+	}
+	assertFloat(t, style.Delta.Score, 0.1)
+
+	if got := findDimension(t, entry, "added"); got.Status != StatusAdded || !got.HasCurrent {
+		t.Fatalf("unexpected added dimension: %+v", got)
+	}
+	if got := findDimension(t, entry, "removed"); got.Status != StatusMissing || !got.HasBaseline {
+		t.Fatalf("unexpected removed dimension: %+v", got)
+	}
+}
+
+func findEntry(t *testing.T, report Report, testName string, caseName string, metric string) Entry {
+	t.Helper()
+	for _, entry := range report.Entries {
+		if entry.Identity.TestName == testName &&
+			entry.Identity.CaseName == caseName &&
+			entry.Identity.Metric == metric {
+			return entry
+		}
+	}
+	t.Fatalf("entry not found: test=%q case=%q metric=%q", testName, caseName, metric)
+	return Entry{}
+}
+
+func findDimension(t *testing.T, entry Entry, name string) DimensionEntry {
+	t.Helper()
+	for _, dimension := range entry.Dimensions {
+		if dimension.Name == name {
+			return dimension
+		}
+	}
+	t.Fatalf("dimension not found: %q in %+v", name, entry.Dimensions)
+	return DimensionEntry{}
+}
+
+func assertFloat(t *testing.T, got float64, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("got %f, want %f", got, want)
+	}
+}

--- a/compare/doc.go
+++ b/compare/doc.go
@@ -1,0 +1,7 @@
+// Package compare compares go-eval JSONL result files.
+//
+// The package is intended for tests and future CLI code that need to compare a
+// baseline run against a current run. By default, rows are matched by test name
+// and metric. Callers that encode a separate case identity in metadata can
+// provide Options.Identity to include that value in the comparison key.
+package compare


### PR DESCRIPTION
## Summary
- add a stdlib-only compare package for baseline-vs-current JSONL result diffs
- report deterministic added, missing, improved, regressed, and unchanged entries
- include score, pass/fail, token, latency, and Compound dimension deltas
- document the API and update the changelog

## Tests
- go test ./...
- go test -race ./...
- golangci-lint run

Closes #13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a stdlib-only `compare` package to diff baseline vs current JSONL eval results. It reports added, missing, improved, regressed, and unchanged rows with score, pass/fail, token, latency, and Compound dimension deltas. Closes #13.

- New Features
  - APIs: `Compare`, `CompareFiles`, `ReadJSONL`, `ReadJSONLFile`, and `Options` (custom `Identity`, `ScoreTolerance`).
  - Deterministic matching by test name + metric; supports case IDs via `Options.Identity`; stable ordering with occurrence index for duplicates.
  - Per-dimension status and pass changes for Compound metrics. README example and changelog updated.

<sup>Written for commit 5f90e02a2884c2c23c4c60d5eb2cc7c9c3a3cb33. Summary will update on new commits. <a href="https://cubic.dev/pr/igcodinap/go-eval/pull/18?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New comparison package for analyzing baseline-vs-current evaluation result regressions from JSONL output files
  * Reports categorize results as improved, regressed, added, missing, or unchanged with comprehensive metrics
  * Detailed deltas tracked for score, tokens, and latency; supports custom identity matching for flexible comparison

<!-- end of auto-generated comment: release notes by coderabbit.ai -->