### PR TITLE
Add JSON dataset loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `authoring-go-eval-suites` agent skill and Claude `/eval` command for designing, running, and reviewing eval suites
 - `compare` package for baseline-vs-current JSONL result regression diffs
 - Minimal `goeval` CLI with `test`, `compare`, and `version` commands
+- JSON dataset loader (`LoadCases`, `LoadNamedCases`, `LoadDataset`) for external golden cases
 
 ## [v0.2.0] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,53 @@ goeval test ./...
 
 Unset `GOEVAL` and evals skip. That keeps CI and local runs safe by default.
 
+## Datasets
+
+Keep golden cases in JSON when you want eval data outside Go test code:
+
+```json
+{
+  "cases": [
+    {
+      "name": "france-capital",
+      "input": "What's the capital of France?",
+      "expected": "Paris",
+      "context": ["Paris is the capital of France."],
+      "metadata": {
+        "flow": "rag.answer",
+        "tier": "critical",
+        "dataset": "capitals/smoke-v1"
+      }
+    }
+  ]
+}
+```
+
+Use `LoadNamedCases` for table-driven tests:
+
+```go
+cases, err := eval.LoadNamedCases("testdata/cases.json")
+if err != nil {
+	t.Fatal(err)
+}
+
+for _, tc := range cases {
+	tc := tc
+	t.Run(tc.Name, func(t *testing.T) {
+		t.Parallel()
+
+		c := tc.Case
+		c.Output, c.Context = runRAG(c.Input)
+
+		r.Run(t, eval.Faithfulness{Threshold: 0.8}, c)
+	})
+}
+```
+
+Use `LoadCases` when names are not needed. The loader is JSON-only and
+stdlib-only; YAML support is deferred to a future subpackage or module so the
+core package stays dependency-free.
+
 ### Tracing judge I/O
 
 Set `GOEVAL_TRACE=1` alongside `GOEVAL=1` to dump every judge prompt and
@@ -103,7 +150,7 @@ GOEVAL=1 GOEVAL_TRACE=1 go test -v -run TestFaithfulness
 | External platform required  | no                  | no                           |
 | Dependencies in core        | pydantic, pytest    | stdlib only                  |
 | Agent / conversation evals  | yes                 | planned v0.3                 |
-| Dataset loaders (YAML/JSON) | yes                 | planned v0.3                 |
+| Dataset loaders             | YAML/JSON           | JSON in core, YAML deferred  |
 | HTML / JSON reports         | yes                 | via `go test -json`          |
 
 `go-eval` is intentionally smaller. v0.2 covers the common case:

--- a/dataset.go
+++ b/dataset.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 // Dataset is the JSON file format for external eval cases.
@@ -202,7 +203,7 @@ func DecodeNamedCases(r io.Reader) ([]NamedCase, error) {
 
 func validateNamedCases(cases []NamedCase) error {
 	for i, c := range cases {
-		if c.Name == "" {
+		if strings.TrimSpace(c.Name) == "" {
 			return fmt.Errorf("case %d: name is required", i+1)
 		}
 	}

--- a/dataset.go
+++ b/dataset.go
@@ -1,0 +1,239 @@
+package eval
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Dataset is the JSON file format for external eval cases.
+//
+// Files are encoded as:
+//
+//	{
+//	  "cases": [
+//	    {
+//	      "name": "france-capital",
+//	      "input": "What is the capital of France?",
+//	      "output": "Paris is the capital of France.",
+//	      "expected": "Paris",
+//	      "context": ["Paris is the capital of France."],
+//	      "metadata": {"flow": "rag.answer", "tier": "critical", "dataset": "smoke/v1"}
+//	    }
+//	  ]
+//	}
+type Dataset struct {
+	Cases []NamedCase `json:"cases"`
+}
+
+// MarshalJSON encodes Dataset with an array-valued cases field, even when empty.
+func (d Dataset) MarshalJSON() ([]byte, error) {
+	cases := d.Cases
+	if cases == nil {
+		cases = []NamedCase{}
+	}
+	var raw struct {
+		Cases []NamedCase `json:"cases"`
+	}
+	raw.Cases = cases
+	return json.Marshal(raw)
+}
+
+// UnmarshalJSON implements strict decoding for the dataset file format.
+func (d *Dataset) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New("dataset is null")
+	}
+
+	var raw struct {
+		Cases json.RawMessage `json:"cases"`
+	}
+	if err := decodeStrictJSON(data, &raw); err != nil {
+		return err
+	}
+	if raw.Cases == nil {
+		return errors.New("cases is required")
+	}
+	if bytes.Equal(bytes.TrimSpace(raw.Cases), []byte("null")) {
+		return errors.New("cases must be an array")
+	}
+
+	var cases []NamedCase
+	if err := decodeStrictJSON(raw.Cases, &cases); err != nil {
+		return fmt.Errorf("cases: %w", err)
+	}
+	d.Cases = cases
+	return nil
+}
+
+// NamedCase pairs a table-driven test name with a Case.
+type NamedCase struct {
+	Name string
+	Case Case
+}
+
+// MarshalJSON encodes NamedCase using the flattened dataset case format.
+func (c NamedCase) MarshalJSON() ([]byte, error) {
+	return json.Marshal(namedCaseJSON{
+		Name:     c.Name,
+		Input:    c.Case.Input,
+		Output:   c.Case.Output,
+		Expected: c.Case.Expected,
+		Context:  c.Case.Context,
+		Metadata: c.Case.Metadata,
+	})
+}
+
+// UnmarshalJSON decodes NamedCase from the flattened dataset case format.
+func (c *NamedCase) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New("case is null")
+	}
+
+	var raw namedCaseJSON
+	if err := decodeStrictJSON(data, &raw); err != nil {
+		return err
+	}
+	c.Name = raw.Name
+	c.Case = Case{
+		Input:    raw.Input,
+		Output:   raw.Output,
+		Expected: raw.Expected,
+		Context:  raw.Context,
+		Metadata: raw.Metadata,
+	}
+	return nil
+}
+
+type namedCaseJSON struct {
+	Name     string         `json:"name,omitempty"`
+	Input    string         `json:"input,omitempty"`
+	Output   string         `json:"output,omitempty"`
+	Expected string         `json:"expected,omitempty"`
+	Context  []string       `json:"context,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// LoadDataset reads a JSON dataset file.
+func LoadDataset(path string) (Dataset, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Dataset{}, fmt.Errorf("open dataset %q: %w", path, err)
+	}
+
+	dataset, readErr := DecodeDataset(f)
+	closeErr := f.Close()
+	if readErr != nil && closeErr != nil {
+		return Dataset{}, errors.Join(
+			fmt.Errorf("load dataset %q: %w", path, readErr),
+			fmt.Errorf("close dataset %q: %w", path, closeErr),
+		)
+	}
+	if readErr != nil {
+		return Dataset{}, fmt.Errorf("load dataset %q: %w", path, readErr)
+	}
+	if closeErr != nil {
+		return Dataset{}, fmt.Errorf("close dataset %q: %w", path, closeErr)
+	}
+	return dataset, nil
+}
+
+// DecodeDataset reads a JSON dataset from r.
+func DecodeDataset(r io.Reader) (Dataset, error) {
+	if r == nil {
+		return Dataset{}, errors.New("decode dataset: reader is nil")
+	}
+
+	var dataset Dataset
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&dataset); err != nil {
+		return Dataset{}, fmt.Errorf("decode dataset: %w", err)
+	}
+	if err := ensureSingleJSONValue(dec); err != nil {
+		return Dataset{}, fmt.Errorf("decode dataset: %w", err)
+	}
+	return dataset, nil
+}
+
+// LoadCases reads a JSON dataset file and returns only the eval cases.
+func LoadCases(path string) ([]Case, error) {
+	dataset, err := LoadDataset(path)
+	if err != nil {
+		return nil, err
+	}
+	return casesOnly(dataset.Cases), nil
+}
+
+// DecodeCases reads a JSON dataset from r and returns only the eval cases.
+func DecodeCases(r io.Reader) ([]Case, error) {
+	dataset, err := DecodeDataset(r)
+	if err != nil {
+		return nil, err
+	}
+	return casesOnly(dataset.Cases), nil
+}
+
+// LoadNamedCases reads a JSON dataset file and requires every case to have a name.
+func LoadNamedCases(path string) ([]NamedCase, error) {
+	dataset, err := LoadDataset(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateNamedCases(dataset.Cases); err != nil {
+		return nil, fmt.Errorf("load named cases %q: %w", path, err)
+	}
+	return dataset.Cases, nil
+}
+
+// DecodeNamedCases reads a JSON dataset from r and requires every case to have a name.
+func DecodeNamedCases(r io.Reader) ([]NamedCase, error) {
+	dataset, err := DecodeDataset(r)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateNamedCases(dataset.Cases); err != nil {
+		return nil, err
+	}
+	return dataset.Cases, nil
+}
+
+func validateNamedCases(cases []NamedCase) error {
+	for i, c := range cases {
+		if c.Name == "" {
+			return fmt.Errorf("case %d: name is required", i+1)
+		}
+	}
+	return nil
+}
+
+func casesOnly(cases []NamedCase) []Case {
+	out := make([]Case, len(cases))
+	for i, c := range cases {
+		out[i] = c.Case
+	}
+	return out
+}
+
+func decodeStrictJSON(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	return ensureSingleJSONValue(dec)
+}
+
+func ensureSingleJSONValue(dec *json.Decoder) error {
+	var extra any
+	err := dec.Decode(&extra)
+	if err == io.EOF {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return errors.New("multiple JSON values")
+}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -1,0 +1,211 @@
+package eval
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDecodeCases_LoadsJSONDataset(t *testing.T) {
+	cases, err := DecodeCases(strings.NewReader(`{
+		"cases": [
+			{
+				"name": "france-capital",
+				"input": "What is the capital of France?",
+				"output": "Paris is the capital of France.",
+				"expected": "Paris",
+				"context": ["Paris is the capital of France."],
+				"metadata": {
+					"flow": "rag.answer",
+					"tier": "critical",
+					"dataset": "capitals/smoke-v1"
+				}
+			}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("DecodeCases: %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("expected one case, got %d", len(cases))
+	}
+
+	got := cases[0]
+	if got.Input != "What is the capital of France?" ||
+		got.Output != "Paris is the capital of France." ||
+		got.Expected != "Paris" {
+		t.Fatalf("unexpected case strings: %+v", got)
+	}
+	if len(got.Context) != 1 || got.Context[0] != "Paris is the capital of France." {
+		t.Fatalf("unexpected context: %+v", got.Context)
+	}
+	if got.Metadata["flow"] != "rag.answer" ||
+		got.Metadata["tier"] != "critical" ||
+		got.Metadata["dataset"] != "capitals/smoke-v1" {
+		t.Fatalf("unexpected metadata: %+v", got.Metadata)
+	}
+}
+
+func TestLoadNamedCases_LoadsNamesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cases.json")
+	if err := os.WriteFile(path, []byte(`{
+		"cases": [
+			{"name": "paris", "input": "What is the capital of France?"},
+			{"name": "rome", "input": "What is the capital of Italy?"}
+		]
+	}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cases, err := LoadNamedCases(path)
+	if err != nil {
+		t.Fatalf("LoadNamedCases: %v", err)
+	}
+	if len(cases) != 2 {
+		t.Fatalf("expected two cases, got %d", len(cases))
+	}
+	if cases[0].Name != "paris" || cases[0].Case.Input != "What is the capital of France?" {
+		t.Fatalf("unexpected first case: %+v", cases[0])
+	}
+	if cases[1].Name != "rome" || cases[1].Case.Input != "What is the capital of Italy?" {
+		t.Fatalf("unexpected second case: %+v", cases[1])
+	}
+}
+
+func TestDecodeCases_EmptyDataset(t *testing.T) {
+	cases, err := DecodeCases(strings.NewReader(`{"cases":[]}`))
+	if err != nil {
+		t.Fatalf("DecodeCases: %v", err)
+	}
+	if len(cases) != 0 {
+		t.Fatalf("expected no cases, got %d", len(cases))
+	}
+	if cases == nil {
+		t.Fatalf("expected empty non-nil cases slice")
+	}
+}
+
+func TestDataset_EmptyMarshalRoundTrip(t *testing.T) {
+	data, err := json.Marshal(Dataset{})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(data) != `{"cases":[]}` {
+		t.Fatalf("expected empty cases array, got %s", data)
+	}
+	if _, err := DecodeDataset(strings.NewReader(string(data))); err != nil {
+		t.Fatalf("DecodeDataset: %v", err)
+	}
+}
+
+func TestDecodeDataset_InvalidFilesReturnClearErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{
+			name:    "malformed json",
+			payload: `{"cases": [`,
+			want:    "decode dataset:",
+		},
+		{
+			name:    "missing cases",
+			payload: `{}`,
+			want:    "cases is required",
+		},
+		{
+			name:    "unknown top-level field",
+			payload: `{"casez":[]}`,
+			want:    `unknown field "casez"`,
+		},
+		{
+			name:    "null cases",
+			payload: `{"cases":null}`,
+			want:    "cases must be an array",
+		},
+		{
+			name:    "unknown case field",
+			payload: `{"cases":[{"name":"france","question":"What is the capital of France?"}]}`,
+			want:    `unknown field "question"`,
+		},
+		{
+			name:    "invalid metadata",
+			payload: `{"cases":[{"name":"france","metadata":[]}]}`,
+			want:    "cannot unmarshal array",
+		},
+		{
+			name:    "null case",
+			payload: `{"cases":[null]}`,
+			want:    "case is null",
+		},
+		{
+			name:    "trailing value",
+			payload: `{"cases":[]} {"cases":[]}`,
+			want:    "multiple JSON values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeDataset(strings.NewReader(tt.payload))
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error %q does not contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeNamedCases_RequiresNames(t *testing.T) {
+	_, err := DecodeNamedCases(strings.NewReader(`{"cases":[{"input":"What is the capital of France?"}]}`))
+	if err == nil {
+		t.Fatalf("expected missing name error")
+	}
+	if !strings.Contains(err.Error(), "case 1: name is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDataset_MetadataRoundTrip(t *testing.T) {
+	want := Dataset{
+		Cases: []NamedCase{
+			{
+				Name: "france-capital",
+				Case: Case{
+					Input:    "What is the capital of France?",
+					Expected: "Paris",
+					Metadata: map[string]any{
+						"flow":    "rag.answer",
+						"tier":    "critical",
+						"dataset": "capitals/smoke-v1",
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	got, err := DecodeDataset(strings.NewReader(string(data)))
+	if err != nil {
+		t.Fatalf("DecodeDataset: %v", err)
+	}
+	if len(got.Cases) != 1 {
+		t.Fatalf("expected one case, got %d", len(got.Cases))
+	}
+	metadata := got.Cases[0].Case.Metadata
+	if metadata["flow"] != "rag.answer" ||
+		metadata["tier"] != "critical" ||
+		metadata["dataset"] != "capitals/smoke-v1" {
+		t.Fatalf("metadata did not round-trip: %+v", metadata)
+	}
+}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -163,12 +163,30 @@ func TestDecodeDataset_InvalidFilesReturnClearErrors(t *testing.T) {
 }
 
 func TestDecodeNamedCases_RequiresNames(t *testing.T) {
-	_, err := DecodeNamedCases(strings.NewReader(`{"cases":[{"input":"What is the capital of France?"}]}`))
-	if err == nil {
-		t.Fatalf("expected missing name error")
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "missing",
+			payload: `{"cases":[{"input":"What is the capital of France?"}]}`,
+		},
+		{
+			name:    "whitespace",
+			payload: `{"cases":[{"name":"   ","input":"What is the capital of France?"}]}`,
+		},
 	}
-	if !strings.Contains(err.Error(), "case 1: name is required") {
-		t.Fatalf("unexpected error: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeNamedCases(strings.NewReader(tt.payload))
+			if err == nil {
+				t.Fatalf("expected missing name error")
+			}
+			if !strings.Contains(err.Error(), "case 1: name is required") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/docs/proposals/0001-v0.3-evaluation-core.md
+++ b/docs/proposals/0001-v0.3-evaluation-core.md
@@ -91,28 +91,30 @@ conversation evaluation should still work naturally from `go test`.
 
 Add a loader for external test cases.
 
-Candidate package:
+Initial JSON format:
 
-```text
-datasets/
+```json
+{
+  "cases": [
+    {
+      "name": "france-capital",
+      "input": "What is the capital of France?",
+      "output": "Paris is the capital of France.",
+      "expected": "Paris",
+      "context": ["Paris is the capital of France."],
+      "metadata": {
+        "flow": "rag.answer",
+        "tier": "critical",
+        "dataset": "smoke/v1"
+      }
+    }
+  ]
+}
 ```
 
-Candidate formats:
-
-```yaml
-cases:
-  - name: france-capital
-    input: What is the capital of France?
-    output: Paris is the capital of France.
-    expected: Paris
-    context:
-      - Paris is the capital of France.
-    metadata:
-      dataset: smoke
-```
-
-The loader should probably live outside the root package if YAML support adds a
-dependency. JSON can remain stdlib-only.
+The JSON loader can live in the root package while remaining stdlib-only. YAML
+support is deferred to a later subpackage or separate module if it adds a
+dependency.
 
 ### JSONL Regression Comparison
 

--- a/examples/rag_app/README.md
+++ b/examples/rag_app/README.md
@@ -1,7 +1,8 @@
 # RAG App Example
 
 Demonstrates a full `go-eval` suite: a toy retriever and generator pipeline
-evaluated with all five metrics under `go test`.
+evaluated with all five metrics under `go test`. Test cases are loaded from
+`testdata/cases.json` with `eval.LoadNamedCases`.
 
 ## Run
 

--- a/examples/rag_app/rag_test.go
+++ b/examples/rag_app/rag_test.go
@@ -22,21 +22,20 @@ func TestRAGEvalSuite(t *testing.T) {
 
 	r := eval.NewRunner(scriptedJudge{})
 
-	cases := []struct {
-		name string
-		q    string
-	}{
-		{name: "paris", q: "What's the capital of France?"},
-		{name: "rome", q: "What's the capital of Italy?"},
+	cases, err := eval.LoadNamedCases("testdata/cases.json")
+	if err != nil {
+		t.Fatalf("LoadNamedCases: %v", err)
 	}
 
 	for _, tc := range cases {
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			answer, docs := p.Answer(tc.q)
-			c := eval.Case{Input: tc.q, Output: answer, Context: docs}
+			c := tc.Case
+			answer, docs := p.Answer(c.Input)
+			c.Output = answer
+			c.Context = docs
 
 			r.Run(t, eval.Faithfulness{Threshold: 0.8}, c)
 			r.Run(t, eval.Hallucination{Threshold: 0.9}, c)

--- a/examples/rag_app/testdata/cases.json
+++ b/examples/rag_app/testdata/cases.json
@@ -1,0 +1,24 @@
+{
+  "cases": [
+    {
+      "name": "france-capital",
+      "input": "What's the capital of France?",
+      "expected": "Paris",
+      "metadata": {
+        "flow": "rag.answer",
+        "tier": "critical",
+        "dataset": "rag_app/smoke-v1"
+      }
+    },
+    {
+      "name": "italy-capital",
+      "input": "What's the capital of Italy?",
+      "expected": "Rome",
+      "metadata": {
+        "flow": "rag.answer",
+        "tier": "standard",
+        "dataset": "rag_app/smoke-v1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add strict JSON dataset loader APIs: LoadDataset, LoadCases, LoadNamedCases, and decode variants.
- Preserve metadata round-tripping for flow/tier/dataset and add invalid/empty dataset coverage.
- Update the RAG example and docs to show file-backed table-driven eval cases.

Fixes #17

## Tests
- go test ./...
- go test -race ./...
- go test -race ./... (examples/rag_app)
- golangci-lint run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a strict, stdlib-only JSON dataset loader for golden eval cases and integrates it into table-driven tests. Updates the RAG example and docs; preserves metadata round-trips and rejects missing or whitespace-only case names.

- **New Features**
  - JSON dataset format with `Dataset` and `NamedCase` types.
  - Loaders: `LoadDataset`, `DecodeDataset`, `LoadCases`, `DecodeCases`, `LoadNamedCases`, `DecodeNamedCases` (strict JSON, single-value, clear errors; names required and whitespace-only rejected for `*NamedCases`).
  - Metadata round-trips for `flow`, `tier`, and `dataset`.
  - RAG example reads `examples/rag_app/testdata/cases.json` via `eval.LoadNamedCases`.
  - Docs: README and proposal updated; JSON in core, YAML deferred.

<sup>Written for commit 543a8fd136f6e1105786d5c7bdc22d104ee8087d. Summary will update on new commits. <a href="https://cubic.dev/pr/igcodinap/go-eval/pull/19?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON dataset loading capability for evaluation test cases, supporting both plain cases and named cases.
  * Introduced documentation and examples for organizing evaluation inputs as JSON "golden cases."
  * RAG example updated to demonstrate loading test data from external JSON files.

* **Documentation**
  * Enhanced README with guidance on storing and loading evaluation datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->