### PR TITLE
Add agent trace evaluation APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Agent trace evaluation APIs: `Message`, `TraceSpan`, `AgentCase`, `AgentMetric`, and `Runner.RunAgent`
+- Agent metrics: `TaskCompletion`, `ToolUseCorrectness`, and `AgentGEval`
+- JSON agent dataset loading with `agent_cases`, `LoadAgentDataset`, and `LoadNamedAgentCases`
+- Trace-aware agent app example and docs for authoring agent eval suites
+
 ## [v0.3.0] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 `go-eval` brings LLM-as-judge metrics to the Go ecosystem.
 Core metrics (Faithfulness, Hallucination, AnswerRelevancy, ContextPrecision,
-GEval, Compound) and deterministic checks run inside standard `go test`, with
-benchmarks, `-parallel`, subtests, and CI integration working out of the box.
+GEval, Compound), agent trace metrics, and deterministic checks run inside
+standard `go test`, with benchmarks, `-parallel`, subtests, and CI integration
+working out of the box.
 
 ## Why
 
@@ -124,6 +125,25 @@ Use `LoadCases` when names are not needed. The loader is JSON-only and
 stdlib-only; YAML support is deferred to a future subpackage or module so the
 core package stays dependency-free.
 
+Agent datasets use a separate top-level key so trace-aware cases cannot be
+confused with single-turn cases:
+
+```json
+{
+  "agent_cases": [
+    {
+      "name": "order-status",
+      "messages": [{"role": "user", "content": "Where is my order?"}],
+      "expected": "Answer with delivery status.",
+      "trace": [{"kind": "tool", "name": "orders.lookup"}],
+      "metadata": {"flow": "support.lookup", "tier": "critical"}
+    }
+  ]
+}
+```
+
+Use `LoadNamedAgentCases` for table-driven agent evals.
+
 ### Tracing judge I/O
 
 Set `GOEVAL_TRACE=1` alongside `GOEVAL=1` to dump every judge prompt and
@@ -145,6 +165,9 @@ GOEVAL=1 GOEVAL_TRACE=1 go test -v -run TestFaithfulness
 | `AnswerRelevancy`  | Output addresses Input                                 | 0.7               |
 | `ContextPrecision` | Retrieved docs are relevant to Input                   | 0.7               |
 | `GEval`            | Custom rubric with Criteria and optional Steps         | 0.7               |
+| `TaskCompletion`   | Agent final output satisfies goal and Expected         | 0.8               |
+| `ToolUseCorrectness` | Agent tool/retrieval trace is necessary and consistent | 0.8             |
+| `AgentGEval`       | Custom rubric over messages, output, context, trace    | 0.7               |
 | `Compound`         | Multiple rubric dimensions in one judge call           | per-dimension     |
 | `Contains`         | Output contains expected substring                      | binary            |
 | `Regex`            | Output matches a regex                                 | binary            |
@@ -160,14 +183,39 @@ GOEVAL=1 GOEVAL_TRACE=1 go test -v -run TestFaithfulness
 | Runs inside test framework  | pytest              | `go test` / `go test -bench` |
 | External platform required  | no                  | no                           |
 | Dependencies in core        | pydantic, pytest    | stdlib only                  |
-| Agent / conversation evals  | yes                 | planned                      |
+| Agent / conversation evals  | yes                 | agent traces yes             |
 | Dataset loaders             | YAML/JSON           | JSON in core, YAML deferred  |
 | HTML / JSON reports         | yes                 | via `go test -json`          |
 
-`go-eval` is intentionally smaller. v0.3 covers the common case:
-scoring RAG-style and deterministic evaluation cases in a CI-friendly way,
-loading JSON datasets, comparing JSONL result runs, and using local Ollama
-judges.
+`go-eval` is intentionally smaller. v0.4 covers RAG-style, deterministic, and
+agent trace evaluation cases in a CI-friendly way, loading JSON datasets,
+comparing JSONL result runs, and using local Ollama judges.
+
+## Agent Trace Evals
+
+Use `AgentCase` when the behavior depends on a multi-turn conversation and a
+trace of tool, retrieval, or LLM steps:
+
+```go
+c := eval.AgentCase{
+	Messages: []eval.Message{
+		{Role: eval.RoleUser, Content: "Where is my order?"},
+	},
+	Output:   "Your order arrives tomorrow.",
+	Expected: "Answer with delivery status.",
+	Trace: []eval.TraceSpan{
+		{Kind: eval.SpanTool, Name: "orders.lookup", Output: "delivery_date=tomorrow"},
+	},
+	Metadata: map[string]any{"flow": "support.lookup", "tier": "critical"},
+}
+
+r.RunAgent(t, eval.TaskCompletion{Threshold: 0.8}, c)
+r.RunAgent(t, eval.ToolUseCorrectness{Threshold: 0.8}, c)
+```
+
+`RunAgent` follows the same `GOEVAL`, timeout, result sink, tracing, and case
+filter behavior as `Run`. Result JSONL rows keep metadata, but not full traces,
+so sensitive tool payloads are not persisted by default.
 
 ## Benchmarks
 
@@ -305,16 +353,16 @@ See `examples/openai_judge/` for a reference implementation.
 
 ## Status
 
-v0.3 - JSON datasets, result comparison, Ollama and OpenAI adapter modules,
-Compound, deterministic metrics, and opt-in result sinks are included. API may
-change before v1.0.
+v0.4 - Agent trace evaluation, JSON agent datasets, result comparison, Ollama
+and OpenAI adapter modules, Compound, deterministic metrics, and opt-in result
+sinks are included. API may change before v1.0.
 
 ## Roadmap
 
 Planned scope:
-1. Conversation evaluation model (`ConversationCase`, `ConversationMetric`, `RunConversation`)
-2. YAML loader submodule (core remains stdlib-only)
-3. Additional adapters beyond Ollama (`Genkit`, `Anthropic`, `Gemini`)
+1. YAML loader submodule (core remains stdlib-only)
+2. Additional adapters beyond Ollama (`Genkit`, `Anthropic`, `Gemini`)
+3. Hosted reporting and richer trace coverage summaries
 
 ## License
 

--- a/agent.go
+++ b/agent.go
@@ -1,0 +1,72 @@
+package eval
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// RoleSystem identifies an instruction or policy message.
+	RoleSystem = "system"
+	// RoleUser identifies an end-user message.
+	RoleUser = "user"
+	// RoleAssistant identifies an assistant message.
+	RoleAssistant = "assistant"
+	// RoleTool identifies a tool result message.
+	RoleTool = "tool"
+)
+
+const (
+	// SpanTool identifies a tool call in an agent trace.
+	SpanTool = "tool"
+	// SpanRetrieval identifies a retrieval step in an agent trace.
+	SpanRetrieval = "retrieval"
+	// SpanLLM identifies an LLM call in an agent trace.
+	SpanLLM = "llm"
+)
+
+// Message is one conversational turn in an agent evaluation case.
+type Message struct {
+	Role       string         `json:"role,omitempty"`
+	Content    string         `json:"content,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+}
+
+// TraceSpan captures one relevant step in an agent run.
+type TraceSpan struct {
+	Kind     string         `json:"kind,omitempty"`
+	Name     string         `json:"name,omitempty"`
+	Input    string         `json:"input,omitempty"`
+	Output   string         `json:"output,omitempty"`
+	Error    string         `json:"error,omitempty"`
+	Context  []string       `json:"context,omitempty"`
+	Latency  time.Duration  `json:"latency,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// AgentCase is a multi-turn, trace-aware evaluation input.
+type AgentCase struct {
+	Messages []Message      `json:"messages,omitempty"`
+	Output   string         `json:"output,omitempty"`
+	Expected string         `json:"expected,omitempty"`
+	Context  []string       `json:"context,omitempty"`
+	Trace    []TraceSpan    `json:"trace,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// AgentMetric is the contract for trace-aware agent evaluations.
+type AgentMetric interface {
+	Name() string
+	ScoreAgent(ctx context.Context, j Judge, c AgentCase) (Result, error)
+}
+
+func (c AgentCase) caseView() Case {
+	return Case{
+		Output:   c.Output,
+		Expected: c.Expected,
+		Context:  c.Context,
+		Metadata: c.Metadata,
+	}
+}

--- a/agent_dataset_test.go
+++ b/agent_dataset_test.go
@@ -1,0 +1,234 @@
+package eval
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDecodeAgentCasesLoadsJSONDataset(t *testing.T) {
+	cases, err := DecodeAgentCases(strings.NewReader(`{
+		"agent_cases": [
+			{
+				"name": "order-status",
+				"messages": [
+					{"role": "user", "content": "Where is my order?"}
+				],
+				"output": "Your order arrives tomorrow.",
+				"expected": "Answer with delivery status.",
+				"context": ["Order 42 delivery date: tomorrow."],
+				"trace": [
+					{
+						"kind": "tool",
+						"name": "orders.lookup",
+						"input": "order_id=42",
+						"output": "delivery_date=tomorrow",
+						"metadata": {"cache_hit": true}
+					}
+				],
+				"metadata": {
+					"flow": "support.lookup",
+					"tier": "critical",
+					"dataset": "support/smoke-v1"
+				}
+			}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("DecodeAgentCases: %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("expected one case, got %d", len(cases))
+	}
+
+	got := cases[0]
+	if len(got.Messages) != 1 || got.Messages[0].Role != RoleUser ||
+		got.Messages[0].Content != "Where is my order?" {
+		t.Fatalf("unexpected messages: %+v", got.Messages)
+	}
+	if got.Output != "Your order arrives tomorrow." || got.Expected != "Answer with delivery status." {
+		t.Fatalf("unexpected output/expected: %+v", got)
+	}
+	if len(got.Trace) != 1 || got.Trace[0].Kind != SpanTool || got.Trace[0].Name != "orders.lookup" {
+		t.Fatalf("unexpected trace: %+v", got.Trace)
+	}
+	if got.Trace[0].Metadata["cache_hit"] != true {
+		t.Fatalf("nested trace metadata did not decode: %+v", got.Trace[0].Metadata)
+	}
+	if got.Metadata["flow"] != "support.lookup" || got.Metadata["tier"] != "critical" {
+		t.Fatalf("unexpected metadata: %+v", got.Metadata)
+	}
+}
+
+func TestLoadNamedAgentCasesLoadsNamesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent_cases.json")
+	if err := os.WriteFile(path, []byte(`{
+		"agent_cases": [
+			{"name": "lookup", "messages": [{"role": "user", "content": "lookup"}]},
+			{"name": "refund", "messages": [{"role": "user", "content": "refund"}]}
+		]
+	}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cases, err := LoadNamedAgentCases(path)
+	if err != nil {
+		t.Fatalf("LoadNamedAgentCases: %v", err)
+	}
+	if len(cases) != 2 {
+		t.Fatalf("expected two cases, got %d", len(cases))
+	}
+	if cases[0].Name != "lookup" || cases[1].Name != "refund" {
+		t.Fatalf("unexpected names: %+v", cases)
+	}
+}
+
+func TestAgentDatasetEmptyMarshalRoundTrip(t *testing.T) {
+	data, err := json.Marshal(AgentDataset{})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(data) != `{"agent_cases":[]}` {
+		t.Fatalf("expected empty agent_cases array, got %s", data)
+	}
+	if _, err := DecodeAgentDataset(strings.NewReader(string(data))); err != nil {
+		t.Fatalf("DecodeAgentDataset: %v", err)
+	}
+}
+
+func TestDecodeAgentDatasetInvalidFilesReturnClearErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{
+			name:    "malformed json",
+			payload: `{"agent_cases": [`,
+			want:    "decode agent dataset:",
+		},
+		{
+			name:    "missing agent_cases",
+			payload: `{}`,
+			want:    "agent_cases is required",
+		},
+		{
+			name:    "unknown top-level field",
+			payload: `{"cases":[]}`,
+			want:    `unknown field "cases"`,
+		},
+		{
+			name:    "null agent_cases",
+			payload: `{"agent_cases":null}`,
+			want:    "agent_cases must be an array",
+		},
+		{
+			name:    "unknown agent case field",
+			payload: `{"agent_cases":[{"name":"lookup","input":"unsupported"}]}`,
+			want:    `unknown field "input"`,
+		},
+		{
+			name:    "unknown nested message field",
+			payload: `{"agent_cases":[{"name":"lookup","messages":[{"speaker":"user"}]}]}`,
+			want:    `unknown field "speaker"`,
+		},
+		{
+			name:    "invalid trace metadata",
+			payload: `{"agent_cases":[{"name":"lookup","trace":[{"metadata":[]}]}]}`,
+			want:    "cannot unmarshal array",
+		},
+		{
+			name:    "null agent case",
+			payload: `{"agent_cases":[null]}`,
+			want:    "agent case is null",
+		},
+		{
+			name:    "trailing value",
+			payload: `{"agent_cases":[]} {"agent_cases":[]}`,
+			want:    "multiple JSON values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeAgentDataset(strings.NewReader(tt.payload))
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error %q does not contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeNamedAgentCasesRequiresNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "missing",
+			payload: `{"agent_cases":[{"messages":[{"role":"user","content":"hi"}]}]}`,
+		},
+		{
+			name:    "whitespace",
+			payload: `{"agent_cases":[{"name":"   ","messages":[{"role":"user","content":"hi"}]}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeNamedAgentCases(strings.NewReader(tt.payload))
+			if err == nil {
+				t.Fatalf("expected missing name error")
+			}
+			if !strings.Contains(err.Error(), "agent case 1: name is required") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestAgentDatasetNestedMetadataRoundTrip(t *testing.T) {
+	want := AgentDataset{
+		Cases: []NamedAgentCase{
+			{
+				Name: "order-status",
+				Case: AgentCase{
+					Messages: []Message{{Role: RoleUser, Content: "Where is my order?"}},
+					Trace: []TraceSpan{
+						{
+							Kind:     SpanTool,
+							Name:     "orders.lookup",
+							Metadata: map[string]any{"cache_hit": true},
+						},
+					},
+					Metadata: map[string]any{"flow": "support.lookup"},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	got, err := DecodeAgentDataset(strings.NewReader(string(data)))
+	if err != nil {
+		t.Fatalf("DecodeAgentDataset: %v", err)
+	}
+	if len(got.Cases) != 1 || len(got.Cases[0].Case.Trace) != 1 {
+		t.Fatalf("unexpected cases: %+v", got.Cases)
+	}
+	if got.Cases[0].Case.Trace[0].Metadata["cache_hit"] != true {
+		t.Fatalf("trace metadata did not round-trip: %+v", got.Cases[0].Case.Trace[0].Metadata)
+	}
+	if got.Cases[0].Case.Metadata["flow"] != "support.lookup" {
+		t.Fatalf("case metadata did not round-trip: %+v", got.Cases[0].Case.Metadata)
+	}
+}

--- a/agent_metrics.go
+++ b/agent_metrics.go
@@ -1,0 +1,74 @@
+package eval
+
+import (
+	"context"
+	_ "embed"
+	"text/template"
+)
+
+//go:embed prompts/task_completion.tmpl
+var taskCompletionTmpl string
+
+//go:embed prompts/tool_use_correctness.tmpl
+var toolUseCorrectnessTmpl string
+
+//go:embed prompts/agent_geval.tmpl
+var agentGEvalTmpl string
+
+var taskCompletionTemplate = template.Must(template.New("task_completion").Parse(taskCompletionTmpl))
+var toolUseCorrectnessTemplate = template.Must(template.New("tool_use_correctness").Parse(toolUseCorrectnessTmpl))
+var agentGEvalTemplate = template.Must(template.New("agent_geval").Funcs(gevalFuncs).Parse(agentGEvalTmpl))
+
+// TaskCompletion measures whether an agent's final output satisfies the user
+// goal and expected outcome.
+type TaskCompletion struct {
+	Threshold float64
+}
+
+// Name implements AgentMetric.
+func (m TaskCompletion) Name() string { return "TaskCompletion" }
+
+// ScoreAgent implements AgentMetric.
+func (m TaskCompletion) ScoreAgent(ctx context.Context, j Judge, c AgentCase) (Result, error) {
+	return runTemplateMetric(ctx, j, taskCompletionTemplate, c, "task_completion", m.Name(), defaultFloat(m.Threshold, 0.8))
+}
+
+// ToolUseCorrectness measures whether an agent's tool and retrieval steps were
+// necessary, correctly sequenced, and consistent with the final answer.
+type ToolUseCorrectness struct {
+	Threshold float64
+}
+
+// Name implements AgentMetric.
+func (m ToolUseCorrectness) Name() string { return "ToolUseCorrectness" }
+
+// ScoreAgent implements AgentMetric.
+func (m ToolUseCorrectness) ScoreAgent(ctx context.Context, j Judge, c AgentCase) (Result, error) {
+	return runTemplateMetric(ctx, j, toolUseCorrectnessTemplate, c, "tool_use_correctness", m.Name(), defaultFloat(m.Threshold, 0.8))
+}
+
+// AgentGEval is a custom trace-aware LLM-as-judge metric driven by a
+// user-supplied rubric.
+type AgentGEval struct {
+	Criteria  string
+	Steps     []string
+	Threshold float64
+}
+
+// Name implements AgentMetric.
+func (m AgentGEval) Name() string { return "AgentGEval" }
+
+// ScoreAgent implements AgentMetric.
+func (m AgentGEval) ScoreAgent(ctx context.Context, j Judge, c AgentCase) (Result, error) {
+	data := struct {
+		AgentCase
+		Criteria string
+		Steps    []string
+	}{
+		AgentCase: c,
+		Criteria:  m.Criteria,
+		Steps:     m.Steps,
+	}
+
+	return runTemplateMetric(ctx, j, agentGEvalTemplate, data, "agent_geval", m.Name(), defaultFloat(m.Threshold, 0.7))
+}

--- a/agent_metrics_test.go
+++ b/agent_metrics_test.go
@@ -1,0 +1,140 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTaskCompletionScoreAgent(t *testing.T) {
+	mj := &MockJudge{Response: JudgeResponse{
+		Score:            0.9,
+		Reason:           "task complete",
+		Tokens:           12,
+		PromptTokens:     5,
+		CompletionTokens: 7,
+	}}
+
+	r, err := TaskCompletion{Threshold: 0.8}.ScoreAgent(context.Background(), mj, sampleAgentCase())
+	if err != nil {
+		t.Fatalf("ScoreAgent: %v", err)
+	}
+
+	if !r.Passed || r.Score != 0.9 || r.Metric != "TaskCompletion" {
+		t.Fatalf("unexpected result: %+v", r)
+	}
+	if r.Tokens != 12 || r.PromptTokens != 5 || r.CompletionTokens != 7 {
+		t.Fatalf("unexpected token fields: %+v", r)
+	}
+	assertPromptContains(t, mj.LastPrompt(), "Where is my order?", "orders.lookup", "arrives tomorrow")
+}
+
+func TestTaskCompletionDefaultThreshold(t *testing.T) {
+	mj := &MockJudge{Response: JudgeResponse{Score: 0.79}}
+
+	r, err := TaskCompletion{}.ScoreAgent(context.Background(), mj, sampleAgentCase())
+	if err != nil {
+		t.Fatalf("ScoreAgent: %v", err)
+	}
+	if r.Passed {
+		t.Fatalf("expected default threshold 0.8 to fail 0.79")
+	}
+}
+
+func TestToolUseCorrectnessScoreAgent(t *testing.T) {
+	mj := &MockJudge{Response: JudgeResponse{Score: 0.85, Reason: "tool use was correct"}}
+
+	r, err := ToolUseCorrectness{Threshold: 0.8}.ScoreAgent(context.Background(), mj, sampleAgentCase())
+	if err != nil {
+		t.Fatalf("ScoreAgent: %v", err)
+	}
+
+	if !r.Passed || r.Metric != "ToolUseCorrectness" {
+		t.Fatalf("unexpected result: %+v", r)
+	}
+	assertPromptContains(t, mj.LastPrompt(), "kind=tool", "orders.lookup", "delivery status")
+}
+
+func TestToolUseCorrectnessDefaultThreshold(t *testing.T) {
+	mj := &MockJudge{Response: JudgeResponse{Score: 0.79}}
+
+	r, err := ToolUseCorrectness{}.ScoreAgent(context.Background(), mj, sampleAgentCase())
+	if err != nil {
+		t.Fatalf("ScoreAgent: %v", err)
+	}
+	if r.Passed {
+		t.Fatalf("expected default threshold 0.8 to fail 0.79")
+	}
+}
+
+func TestAgentGEvalIncludesCriteriaStepsAndTrace(t *testing.T) {
+	mj := &MockJudge{Response: JudgeResponse{Score: 0.9}}
+
+	_, err := AgentGEval{
+		Criteria: "The agent must answer with a concise status update.",
+		Steps:    []string{"Check task completion.", "Check trace consistency."},
+	}.ScoreAgent(context.Background(), mj, sampleAgentCase())
+	if err != nil {
+		t.Fatalf("ScoreAgent: %v", err)
+	}
+
+	assertPromptContains(t, mj.LastPrompt(),
+		"The agent must answer with a concise status update.",
+		"1. Check task completion.",
+		"2. Check trace consistency.",
+		"orders.lookup",
+	)
+}
+
+func TestAgentGEvalDefaultThreshold(t *testing.T) {
+	mj := &MockJudge{Response: JudgeResponse{Score: 0.69}}
+
+	r, err := AgentGEval{Criteria: "x"}.ScoreAgent(context.Background(), mj, AgentCase{})
+	if err != nil {
+		t.Fatalf("ScoreAgent: %v", err)
+	}
+	if r.Passed {
+		t.Fatalf("expected default threshold 0.7 to fail 0.69")
+	}
+}
+
+func TestAgentMetricReturnsJudgeError(t *testing.T) {
+	sentinel := errors.New("malformed judge response")
+	mj := &MockJudge{Err: sentinel}
+
+	_, err := TaskCompletion{}.ScoreAgent(context.Background(), mj, sampleAgentCase())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ScoreAgent err=%v, want %v", err, sentinel)
+	}
+}
+
+func sampleAgentCase() AgentCase {
+	return AgentCase{
+		Messages: []Message{
+			{Role: RoleUser, Content: "Where is my order?"},
+			{Role: RoleAssistant, Content: "I will check the order system."},
+		},
+		Output:   "Your order arrives tomorrow.",
+		Expected: "Answer with delivery status.",
+		Context:  []string{"Order 42 delivery date: tomorrow."},
+		Trace: []TraceSpan{
+			{
+				Kind:   SpanTool,
+				Name:   "orders.lookup",
+				Input:  "order_id=42",
+				Output: "delivery_date=tomorrow",
+			},
+		},
+	}
+}
+
+func assertPromptContains(t *testing.T, prompt string, wants ...string) {
+	t.Helper()
+
+	for _, want := range wants {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,0 +1,180 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type scriptedAgentMetric struct {
+	name   string
+	result Result
+	err    error
+	calls  int
+}
+
+func (m *scriptedAgentMetric) Name() string { return m.name }
+
+func (m *scriptedAgentMetric) ScoreAgent(ctx context.Context, j Judge, c AgentCase) (Result, error) {
+	m.calls++
+	return m.result, m.err
+}
+
+func TestRunner_RunAgentSkipsWhenGoevalUnset(t *testing.T) {
+	t.Setenv(EnvVar, "")
+
+	tb := &recordingTB{}
+	metric := &scriptedAgentMetric{name: "AgentX", result: Result{Score: 1, Passed: true}}
+	r := NewRunner(&MockJudge{})
+
+	_ = r.RunAgent(tb, metric, AgentCase{})
+
+	if !tb.skipped {
+		t.Fatalf("expected Skip when GOEVAL unset")
+	}
+	if metric.calls != 0 {
+		t.Fatalf("expected skipped case not to call metric, got %d calls", metric.calls)
+	}
+}
+
+func TestRunner_RunAgentWithCaseFilterSkipsUnmatchedCase(t *testing.T) {
+	t.Setenv(EnvVar, "1")
+
+	tb := &recordingTB{}
+	metric := &scriptedAgentMetric{name: "AgentX", result: Result{Score: 1, Passed: true}}
+	r := NewRunner(&MockJudge{}, WithCaseFilter(func(c Case) bool {
+		return c.Metadata["tier"] == "critical"
+	}))
+
+	got := r.RunAgent(tb, metric, AgentCase{Metadata: map[string]any{"tier": "standard"}})
+
+	if !tb.skipped {
+		t.Fatalf("expected case filter to skip")
+	}
+	if metric.calls != 0 {
+		t.Fatalf("expected skipped case not to call metric, got %d calls", metric.calls)
+	}
+	if got.Score != 0 || got.Passed || got.Metadata != nil {
+		t.Fatalf("expected zero result for skipped case, got %+v", got)
+	}
+}
+
+func TestRunner_RunAgentCopiesAgentMetadataToResultAndSink(t *testing.T) {
+	t.Setenv(EnvVar, "1")
+
+	sink := &recordingSink{}
+	r := NewRunner(&MockJudge{}, WithResultSink(sink))
+	c := AgentCase{Metadata: map[string]any{
+		"flow":     "support.lookup",
+		"tier":     "critical",
+		"trace_id": "trace-123",
+	}}
+
+	got := r.RunAgent(t, &scriptedAgentMetric{
+		name:   "AgentX",
+		result: Result{Score: 0.9, Passed: true, Reason: "ok"},
+	}, c)
+
+	if got.Metadata["trace_id"] != "trace-123" {
+		t.Fatalf("expected copied metadata, got %+v", got.Metadata)
+	}
+	got.Metadata["trace_id"] = "changed"
+	if c.Metadata["trace_id"] != "trace-123" {
+		t.Fatalf("metadata was not copied: %+v", c.Metadata)
+	}
+	if sink.count() != 1 {
+		t.Fatalf("expected one sink write, got %d", sink.count())
+	}
+	if sink.last().Metadata["flow"] != "support.lookup" {
+		t.Fatalf("unexpected sink metadata: %+v", sink.last().Metadata)
+	}
+}
+
+func TestRunner_RunAgentPreservesMetricMetadata(t *testing.T) {
+	t.Setenv(EnvVar, "1")
+
+	r := NewRunner(&MockJudge{})
+	got := r.RunAgent(t, &scriptedAgentMetric{
+		name: "AgentX",
+		result: Result{
+			Score:    1,
+			Passed:   true,
+			Metadata: map[string]any{"metric": "kept"},
+		},
+	}, AgentCase{Metadata: map[string]any{"case": "ignored"}})
+
+	if got.Metadata["metric"] != "kept" {
+		t.Fatalf("expected metric metadata to be preserved, got %+v", got.Metadata)
+	}
+	if _, ok := got.Metadata["case"]; ok {
+		t.Fatalf("did not expect case metadata merge, got %+v", got.Metadata)
+	}
+}
+
+func TestRunner_RunAgentFillsMetricNameAndLatency(t *testing.T) {
+	t.Setenv(EnvVar, "1")
+
+	r := NewRunner(&MockJudge{})
+	got := r.RunAgent(t, &scriptedAgentMetric{
+		name:   "AgentX",
+		result: Result{Score: 1, Passed: true},
+	}, AgentCase{})
+
+	if got.Metric != "AgentX" {
+		t.Fatalf("Metric = %q, want AgentX", got.Metric)
+	}
+	if got.Latency <= 0 {
+		t.Fatalf("expected latency to be filled, got %s", got.Latency)
+	}
+}
+
+func TestRunner_RunAgentFatalsOnMetricError(t *testing.T) {
+	t.Setenv(EnvVar, "1")
+
+	tb := &recordingTB{}
+	r := NewRunner(&MockJudge{})
+	_ = r.RunAgent(tb, &scriptedAgentMetric{name: "AgentX", err: errors.New("boom")}, AgentCase{})
+
+	if !tb.fataled {
+		t.Fatalf("expected Fatalf on metric error")
+	}
+}
+
+func TestRunner_RunAgentErrorsOnLowScore(t *testing.T) {
+	t.Setenv(EnvVar, "1")
+
+	tb := &recordingTB{}
+	r := NewRunner(&MockJudge{})
+	_ = r.RunAgent(tb, &scriptedAgentMetric{
+		name:   "AgentX",
+		result: Result{Score: 0.4, Passed: false, Reason: "bad"},
+	}, AgentCase{})
+
+	if !tb.errored {
+		t.Fatalf("expected Errorf when result.Passed == false")
+	}
+}
+
+func TestAgentCaseViewCarriesSharedFields(t *testing.T) {
+	c := AgentCase{
+		Output:   "done",
+		Expected: "done well",
+		Context:  []string{"ctx"},
+		Metadata: map[string]any{"tier": "critical"},
+	}
+
+	got := c.caseView()
+
+	if got.Output != c.Output || got.Expected != c.Expected || got.Context[0] != "ctx" ||
+		got.Metadata["tier"] != "critical" {
+		t.Fatalf("unexpected case view: %+v", got)
+	}
+}
+
+func TestTraceSpanLatencyIsDuration(t *testing.T) {
+	span := TraceSpan{Latency: 50 * time.Millisecond}
+	if span.Latency != 50*time.Millisecond {
+		t.Fatalf("unexpected latency: %s", span.Latency)
+	}
+}

--- a/dataset.go
+++ b/dataset.go
@@ -30,6 +30,26 @@ type Dataset struct {
 	Cases []NamedCase `json:"cases"`
 }
 
+// AgentDataset is the JSON file format for external agent eval cases.
+//
+// Files are encoded as:
+//
+//	{
+//	  "agent_cases": [
+//	    {
+//	      "name": "support-tool-use",
+//	      "messages": [{"role": "user", "content": "Where is my order?"}],
+//	      "output": "Your order arrives tomorrow.",
+//	      "expected": "Answer with delivery status.",
+//	      "trace": [{"kind": "tool", "name": "orders.lookup"}],
+//	      "metadata": {"flow": "support.lookup", "tier": "critical"}
+//	    }
+//	  ]
+//	}
+type AgentDataset struct {
+	Cases []NamedAgentCase `json:"agent_cases"`
+}
+
 // MarshalJSON encodes Dataset with an array-valued cases field, even when empty.
 func (d Dataset) MarshalJSON() ([]byte, error) {
 	cases := d.Cases
@@ -70,10 +90,57 @@ func (d *Dataset) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON encodes AgentDataset with an array-valued agent_cases field,
+// even when empty.
+func (d AgentDataset) MarshalJSON() ([]byte, error) {
+	cases := d.Cases
+	if cases == nil {
+		cases = []NamedAgentCase{}
+	}
+	var raw struct {
+		Cases []NamedAgentCase `json:"agent_cases"`
+	}
+	raw.Cases = cases
+	return json.Marshal(raw)
+}
+
+// UnmarshalJSON implements strict decoding for the agent dataset file format.
+func (d *AgentDataset) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New("agent dataset is null")
+	}
+
+	var raw struct {
+		Cases json.RawMessage `json:"agent_cases"`
+	}
+	if err := decodeStrictJSON(data, &raw); err != nil {
+		return err
+	}
+	if raw.Cases == nil {
+		return errors.New("agent_cases is required")
+	}
+	if bytes.Equal(bytes.TrimSpace(raw.Cases), []byte("null")) {
+		return errors.New("agent_cases must be an array")
+	}
+
+	var cases []NamedAgentCase
+	if err := decodeStrictJSON(raw.Cases, &cases); err != nil {
+		return fmt.Errorf("agent_cases: %w", err)
+	}
+	d.Cases = cases
+	return nil
+}
+
 // NamedCase pairs a table-driven test name with a Case.
 type NamedCase struct {
 	Name string
 	Case Case
+}
+
+// NamedAgentCase pairs a table-driven test name with an AgentCase.
+type NamedAgentCase struct {
+	Name string
+	Case AgentCase
 }
 
 // MarshalJSON encodes NamedCase using the flattened dataset case format.
@@ -109,12 +176,57 @@ func (c *NamedCase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON encodes NamedAgentCase using the flattened agent dataset format.
+func (c NamedAgentCase) MarshalJSON() ([]byte, error) {
+	return json.Marshal(namedAgentCaseJSON{
+		Name:     c.Name,
+		Messages: c.Case.Messages,
+		Output:   c.Case.Output,
+		Expected: c.Case.Expected,
+		Context:  c.Case.Context,
+		Trace:    c.Case.Trace,
+		Metadata: c.Case.Metadata,
+	})
+}
+
+// UnmarshalJSON decodes NamedAgentCase from the flattened agent dataset format.
+func (c *NamedAgentCase) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New("agent case is null")
+	}
+
+	var raw namedAgentCaseJSON
+	if err := decodeStrictJSON(data, &raw); err != nil {
+		return err
+	}
+	c.Name = raw.Name
+	c.Case = AgentCase{
+		Messages: raw.Messages,
+		Output:   raw.Output,
+		Expected: raw.Expected,
+		Context:  raw.Context,
+		Trace:    raw.Trace,
+		Metadata: raw.Metadata,
+	}
+	return nil
+}
+
 type namedCaseJSON struct {
 	Name     string         `json:"name,omitempty"`
 	Input    string         `json:"input,omitempty"`
 	Output   string         `json:"output,omitempty"`
 	Expected string         `json:"expected,omitempty"`
 	Context  []string       `json:"context,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+type namedAgentCaseJSON struct {
+	Name     string         `json:"name,omitempty"`
+	Messages []Message      `json:"messages,omitempty"`
+	Output   string         `json:"output,omitempty"`
+	Expected string         `json:"expected,omitempty"`
+	Context  []string       `json:"context,omitempty"`
+	Trace    []TraceSpan    `json:"trace,omitempty"`
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
@@ -142,6 +254,30 @@ func LoadDataset(path string) (Dataset, error) {
 	return dataset, nil
 }
 
+// LoadAgentDataset reads a JSON agent dataset file.
+func LoadAgentDataset(path string) (AgentDataset, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return AgentDataset{}, fmt.Errorf("open agent dataset %q: %w", path, err)
+	}
+
+	dataset, readErr := DecodeAgentDataset(f)
+	closeErr := f.Close()
+	if readErr != nil && closeErr != nil {
+		return AgentDataset{}, errors.Join(
+			fmt.Errorf("load agent dataset %q: %w", path, readErr),
+			fmt.Errorf("close agent dataset %q: %w", path, closeErr),
+		)
+	}
+	if readErr != nil {
+		return AgentDataset{}, fmt.Errorf("load agent dataset %q: %w", path, readErr)
+	}
+	if closeErr != nil {
+		return AgentDataset{}, fmt.Errorf("close agent dataset %q: %w", path, closeErr)
+	}
+	return dataset, nil
+}
+
 // DecodeDataset reads a JSON dataset from r.
 func DecodeDataset(r io.Reader) (Dataset, error) {
 	if r == nil {
@@ -159,6 +295,23 @@ func DecodeDataset(r io.Reader) (Dataset, error) {
 	return dataset, nil
 }
 
+// DecodeAgentDataset reads a JSON agent dataset from r.
+func DecodeAgentDataset(r io.Reader) (AgentDataset, error) {
+	if r == nil {
+		return AgentDataset{}, errors.New("decode agent dataset: reader is nil")
+	}
+
+	var dataset AgentDataset
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&dataset); err != nil {
+		return AgentDataset{}, fmt.Errorf("decode agent dataset: %w", err)
+	}
+	if err := ensureSingleJSONValue(dec); err != nil {
+		return AgentDataset{}, fmt.Errorf("decode agent dataset: %w", err)
+	}
+	return dataset, nil
+}
+
 // LoadCases reads a JSON dataset file and returns only the eval cases.
 func LoadCases(path string) ([]Case, error) {
 	dataset, err := LoadDataset(path)
@@ -166,6 +319,15 @@ func LoadCases(path string) ([]Case, error) {
 		return nil, err
 	}
 	return casesOnly(dataset.Cases), nil
+}
+
+// LoadAgentCases reads a JSON agent dataset file and returns only the eval cases.
+func LoadAgentCases(path string) ([]AgentCase, error) {
+	dataset, err := LoadAgentDataset(path)
+	if err != nil {
+		return nil, err
+	}
+	return agentCasesOnly(dataset.Cases), nil
 }
 
 // DecodeCases reads a JSON dataset from r and returns only the eval cases.
@@ -177,6 +339,15 @@ func DecodeCases(r io.Reader) ([]Case, error) {
 	return casesOnly(dataset.Cases), nil
 }
 
+// DecodeAgentCases reads a JSON agent dataset from r and returns only the eval cases.
+func DecodeAgentCases(r io.Reader) ([]AgentCase, error) {
+	dataset, err := DecodeAgentDataset(r)
+	if err != nil {
+		return nil, err
+	}
+	return agentCasesOnly(dataset.Cases), nil
+}
+
 // LoadNamedCases reads a JSON dataset file and requires every case to have a name.
 func LoadNamedCases(path string) ([]NamedCase, error) {
 	dataset, err := LoadDataset(path)
@@ -185,6 +356,19 @@ func LoadNamedCases(path string) ([]NamedCase, error) {
 	}
 	if err := validateNamedCases(dataset.Cases); err != nil {
 		return nil, fmt.Errorf("load named cases %q: %w", path, err)
+	}
+	return dataset.Cases, nil
+}
+
+// LoadNamedAgentCases reads a JSON agent dataset file and requires every case
+// to have a name.
+func LoadNamedAgentCases(path string) ([]NamedAgentCase, error) {
+	dataset, err := LoadAgentDataset(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateNamedAgentCases(dataset.Cases); err != nil {
+		return nil, fmt.Errorf("load named agent cases %q: %w", path, err)
 	}
 	return dataset.Cases, nil
 }
@@ -201,6 +385,19 @@ func DecodeNamedCases(r io.Reader) ([]NamedCase, error) {
 	return dataset.Cases, nil
 }
 
+// DecodeNamedAgentCases reads a JSON agent dataset from r and requires every
+// case to have a name.
+func DecodeNamedAgentCases(r io.Reader) ([]NamedAgentCase, error) {
+	dataset, err := DecodeAgentDataset(r)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateNamedAgentCases(dataset.Cases); err != nil {
+		return nil, err
+	}
+	return dataset.Cases, nil
+}
+
 func validateNamedCases(cases []NamedCase) error {
 	for i, c := range cases {
 		if strings.TrimSpace(c.Name) == "" {
@@ -210,8 +407,25 @@ func validateNamedCases(cases []NamedCase) error {
 	return nil
 }
 
+func validateNamedAgentCases(cases []NamedAgentCase) error {
+	for i, c := range cases {
+		if strings.TrimSpace(c.Name) == "" {
+			return fmt.Errorf("agent case %d: name is required", i+1)
+		}
+	}
+	return nil
+}
+
 func casesOnly(cases []NamedCase) []Case {
 	out := make([]Case, len(cases))
+	for i, c := range cases {
+		out[i] = c.Case
+	}
+	return out
+}
+
+func agentCasesOnly(cases []NamedAgentCase) []AgentCase {
+	out := make([]AgentCase, len(cases))
 	for i, c := range cases {
 		out[i] = c.Case
 	}

--- a/docs/agent-skills/authoring-go-eval-suites/references/metrics-reference.md
+++ b/docs/agent-skills/authoring-go-eval-suites/references/metrics-reference.md
@@ -59,6 +59,39 @@ For LLM-judge metrics, "typically needed fields" are not hard-validated by the l
 - Anti-pattern: vague criteria such as "answer well" without observable requirements.
 - Prompt: `prompts/geval.tmpl`.
 
+## TaskCompletion
+
+- Typically needed fields: `AgentCase.Messages`, `AgentCase.Output`, `AgentCase.Expected`.
+- Optional fields: `AgentCase.Context`, `AgentCase.Trace`.
+- Score: judge estimate that the final agent output satisfies the user's goal and expected outcome.
+- Default threshold: `0.8`.
+- Use for: end-to-end agent task success.
+- Avoid for: diagnosing tool sequencing; pair with `ToolUseCorrectness`.
+- Anti-pattern: leaving `Expected` vague when the task has clear success criteria.
+- Prompt: `prompts/task_completion.tmpl`.
+
+## ToolUseCorrectness
+
+- Typically needed fields: `AgentCase.Messages`, `AgentCase.Output`, `AgentCase.Trace`.
+- Optional fields: `AgentCase.Expected`, `AgentCase.Context`.
+- Score: judge estimate that tool/retrieval steps were necessary, correctly sequenced, and consistent with the final answer.
+- Default threshold: `0.8`.
+- Use for: tool-calling agents, retrieval agents, multi-step workflows.
+- Avoid for: pure single-turn answer quality; use `AnswerRelevancy`, `Faithfulness`, or `TaskCompletion`.
+- Anti-pattern: storing sensitive tool payloads in result metadata instead of trace-only test inputs.
+- Prompt: `prompts/tool_use_correctness.tmpl`.
+
+## AgentGEval
+
+- Typically needed fields: whatever the custom `Criteria` and optional `Steps` inspect.
+- Optional fields: all `AgentCase` fields may be referenced by the rubric.
+- Score: judge applies a custom rubric to messages, final output, context, and trace.
+- Default threshold: `0.7`.
+- Use for: domain-specific agent policies and workflow quality.
+- Avoid for: checks that deterministic output assertions can catch.
+- Anti-pattern: mixing unrelated task, safety, and trace concerns into one broad rubric.
+- Prompt: `prompts/agent_geval.tmpl`.
+
 ## Compound
 
 - Typically needed fields: fields used by each dimension.

--- a/docs/agent-skills/authoring-go-eval-suites/references/report-template.md
+++ b/docs/agent-skills/authoring-go-eval-suites/references/report-template.md
@@ -41,6 +41,9 @@ Newly passing:  <list>
 
 ## Coverage
 Agent flows declared in Case.Metadata["flow"]:  <set>
+Agent flows declared in AgentCase.Metadata["flow"]: <set>
+Trace span kinds covered:                       <tool|retrieval|llm>
+Trace span names covered:                       <set>
 Flows found in agent code, best effort:         <set>
 Uncovered flows:                                <list>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,8 +2,8 @@
 
 This guide starts with a local, deterministic eval you can copy into any Go
 project. Then it shows the same shape with an OpenAI-backed judge, RAG metrics,
-deterministic checks, `Compound`, `Precheck`, JSONL result output, and
-benchmarks.
+agent trace metrics, deterministic checks, `Compound`, `Precheck`, JSONL result
+output, and benchmarks.
 
 `go-eval` runs inside `go test`. Eval runs are opt-in: `Runner.Run` and
 `eval.Bench` skip unless `GOEVAL=1` is set. This keeps normal local runs and CI
@@ -87,6 +87,51 @@ GOEVAL=1 go test ./...
 Without `GOEVAL=1`, the eval calls skip. With `GOEVAL=1`, `Runner` executes each
 metric and reports low scores with `t.Errorf`. Judge or metric execution errors
 are fatal.
+
+## Evaluate an Agent Trace
+
+Use `AgentCase` for multi-turn workflows that call tools, retrieve context, or
+make multiple LLM calls.
+
+```go
+func TestAgentTraceEval(t *testing.T) {
+	judge := deterministicJudge{}
+	r := eval.NewRunner(judge)
+
+	c := eval.AgentCase{
+		Messages: []eval.Message{
+			{Role: eval.RoleUser, Content: "Where is my order?"},
+		},
+		Output:   "Your order arrives tomorrow.",
+		Expected: "Answer with delivery status.",
+		Context:  []string{"Order 42 delivery date: tomorrow."},
+		Trace: []eval.TraceSpan{
+			{
+				Kind:   eval.SpanTool,
+				Name:   "orders.lookup",
+				Input:  "order_id=42",
+				Output: "delivery_date=tomorrow",
+			},
+		},
+		Metadata: map[string]any{
+			"flow":    "support.lookup",
+			"tier":    "critical",
+			"dataset": "agent-smoke/v1",
+		},
+	}
+
+	r.RunAgent(t, eval.TaskCompletion{Threshold: 0.8}, c)
+	r.RunAgent(t, eval.ToolUseCorrectness{Threshold: 0.8}, c)
+	r.RunAgent(t, eval.AgentGEval{
+		Criteria:  "The agent must provide a concise, grounded status update.",
+		Threshold: 0.7,
+	}, c)
+}
+```
+
+`RunAgent` has the same eval gate, timeout, result sink, tracing, and
+`WithCaseFilter` behavior as `Run`. Result JSONL rows copy `AgentCase.Metadata`
+but do not persist full traces by default.
 
 ## Use an Ollama Judge
 

--- a/eval.go
+++ b/eval.go
@@ -104,6 +104,8 @@ func (r *Runner) runResult(
 	score func(context.Context, Judge) (Result, error),
 	metadata map[string]any,
 ) Result {
+	tb.Helper()
+
 	ctx, cancel := runnerContext(r.timeout)
 	defer cancel()
 

--- a/eval.go
+++ b/eval.go
@@ -72,29 +72,57 @@ func (r *Runner) Run(tb testing.TB, m Metric, c Case) Result {
 		return Result{}
 	}
 
+	return r.runResult(tb, m.Name(), func(ctx context.Context, j Judge) (Result, error) {
+		return m.Score(ctx, j, c)
+	}, c.Metadata)
+}
+
+// RunAgent executes one agent metric against one agent case and asserts via tb.
+//
+// It mirrors Run while scoring an AgentCase with an AgentMetric. Case filters
+// apply to the AgentCase metadata through the same Case view used by Run.
+func (r *Runner) RunAgent(tb testing.TB, m AgentMetric, c AgentCase) Result {
+	tb.Helper()
+
+	if os.Getenv(EnvVar) == "" {
+		tb.Skip("eval skipped, set " + EnvVar + "=1 to run")
+		return Result{}
+	}
+	if r.caseFilter != nil && !r.caseFilter(c.caseView()) {
+		tb.Skip("eval skipped by case filter")
+		return Result{}
+	}
+
+	return r.runResult(tb, m.Name(), func(ctx context.Context, j Judge) (Result, error) {
+		return m.ScoreAgent(ctx, j, c)
+	}, c.Metadata)
+}
+
+func (r *Runner) runResult(
+	tb testing.TB,
+	metricName string,
+	score func(context.Context, Judge) (Result, error),
+	metadata map[string]any,
+) Result {
 	ctx, cancel := runnerContext(r.timeout)
 	defer cancel()
 
 	judge := maybeTrace(r.judge, tb)
 
 	start := time.Now()
-	result, err := m.Score(ctx, judge, c)
-	if result.Metadata == nil && len(c.Metadata) > 0 {
-		metadata := make(map[string]any, len(c.Metadata))
-		for k, v := range c.Metadata {
-			metadata[k] = v
-		}
-		result.Metadata = metadata
+	result, err := score(ctx, judge)
+	if result.Metadata == nil && len(metadata) > 0 {
+		result.Metadata = copyMetadata(metadata)
 	}
 	if result.Metric == "" {
-		result.Metric = m.Name()
+		result.Metric = metricName
 	}
 	if result.Latency == 0 {
 		result.Latency = time.Since(start)
 	}
 
 	if err != nil {
-		tb.Fatalf("%s: judge error: %v", m.Name(), err)
+		tb.Fatalf("%s: judge error: %v", metricName, err)
 		return result
 	}
 
@@ -107,6 +135,14 @@ func (r *Runner) Run(tb testing.TB, m Metric, c Case) Result {
 	tb.Logf("%s=%.2f pass (reason: %s)", result.Metric, result.Score, result.Reason)
 	r.writeResult(tb, result)
 	return result
+}
+
+func copyMetadata(metadata map[string]any) map[string]any {
+	out := make(map[string]any, len(metadata))
+	for k, v := range metadata {
+		out[k] = v
+	}
+	return out
 }
 
 func (r *Runner) writeResult(tb testing.TB, result Result) {

--- a/examples/agent_app/README.md
+++ b/examples/agent_app/README.md
@@ -1,0 +1,11 @@
+# Agent App Example
+
+This example shows trace-aware agent evals with `RunAgent`.
+
+```bash
+go test ./...
+GOEVAL=1 go test ./...
+```
+
+Unset `GOEVAL` and the evals skip. Set it and the suite scores the final
+answer with `TaskCompletion` and the trace with `ToolUseCorrectness`.

--- a/examples/agent_app/agent.go
+++ b/examples/agent_app/agent.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	eval "github.com/igcodinap/go-eval"
+)
+
+type Agent struct {
+	Orders map[string]string
+}
+
+func (a *Agent) Answer(input string) (string, []eval.TraceSpan) {
+	trace := []eval.TraceSpan{
+		{
+			Kind:    eval.SpanLLM,
+			Name:    "planner",
+			Input:   input,
+			Output:  "look up order status",
+			Latency: 5 * time.Millisecond,
+		},
+	}
+
+	orderID := "42"
+	status := a.Orders[orderID]
+	if status == "" {
+		status = "unknown"
+	}
+
+	trace = append(trace, eval.TraceSpan{
+		Kind:    eval.SpanTool,
+		Name:    "orders.lookup",
+		Input:   "order_id=" + orderID,
+		Output:  status,
+		Latency: 2 * time.Millisecond,
+		Metadata: map[string]any{
+			"tool_version": "demo",
+		},
+	})
+
+	output := "Your order status is " + status + "."
+	if strings.Contains(strings.ToLower(status), "tomorrow") {
+		output = "Your order arrives tomorrow."
+	}
+	return output, trace
+}

--- a/examples/agent_app/agent_test.go
+++ b/examples/agent_app/agent_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	eval "github.com/igcodinap/go-eval"
+)
+
+type scriptedJudge struct{}
+
+func (scriptedJudge) Evaluate(ctx context.Context, prompt string) (eval.JudgeResponse, error) {
+	_ = ctx
+	_ = prompt
+	return eval.JudgeResponse{Score: 0.9, Reason: "canned demo response", Tokens: 42}, nil
+}
+
+func TestAgentEvalSuite(t *testing.T) {
+	agent := &Agent{Orders: map[string]string{"42": "arrives tomorrow"}}
+	r := eval.NewRunner(scriptedJudge{})
+
+	cases := []struct {
+		name string
+		eval.AgentCase
+	}{
+		{
+			name: "order-status",
+			AgentCase: eval.AgentCase{
+				Messages: []eval.Message{
+					{Role: eval.RoleUser, Content: "Where is my order?"},
+				},
+				Expected: "Answer with the delivery status.",
+				Metadata: map[string]any{
+					"flow":    "support.order_status",
+					"tier":    "critical",
+					"dataset": "agent-demo/v1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := tc.AgentCase
+			c.Output, c.Trace = agent.Answer(c.Messages[0].Content)
+
+			r.RunAgent(t, eval.TaskCompletion{Threshold: 0.8}, c)
+			r.RunAgent(t, eval.ToolUseCorrectness{Threshold: 0.8}, c)
+		})
+	}
+}

--- a/examples/agent_app/agent_test.go
+++ b/examples/agent_app/agent_test.go
@@ -16,6 +16,8 @@ func (scriptedJudge) Evaluate(ctx context.Context, prompt string) (eval.JudgeRes
 }
 
 func TestAgentEvalSuite(t *testing.T) {
+	t.Setenv(eval.EnvVar, "1")
+
 	agent := &Agent{Orders: map[string]string{"42": "arrives tomorrow"}}
 	r := eval.NewRunner(scriptedJudge{})
 

--- a/examples/agent_app/go.mod
+++ b/examples/agent_app/go.mod
@@ -1,0 +1,7 @@
+module github.com/igcodinap/go-eval/examples/agent_app
+
+go 1.22
+
+require github.com/igcodinap/go-eval v0.0.0
+
+replace github.com/igcodinap/go-eval => ../..

--- a/prompts/agent_geval.tmpl
+++ b/prompts/agent_geval.tmpl
@@ -15,12 +15,14 @@ EXPECTED OUTCOME:
 FINAL OUTPUT:
 {{.Output}}
 
+{{if .Context}}
 AVAILABLE CONTEXT:
 {{range .Context}}- {{.}}
-{{end}}
+{{end}}{{end}}
+{{if .Trace}}
 TRACE:
 {{range .Trace}}- kind={{.Kind}} name={{.Name}}{{if .Input}} input={{.Input}}{{end}}{{if .Output}} output={{.Output}}{{end}}{{if .Error}} error={{.Error}}{{end}}
-{{end}}
+{{end}}{{end}}
 Return a score from 0.0 (fails the criteria entirely) to 1.0 (meets the
 criteria perfectly).
 

--- a/prompts/agent_geval.tmpl
+++ b/prompts/agent_geval.tmpl
@@ -1,0 +1,28 @@
+You are evaluating an agent run against a custom rubric.
+
+CRITERIA:
+{{.Criteria}}
+{{if .Steps}}
+EVALUATION STEPS (follow in order):
+{{range $i, $step := .Steps}}{{add $i 1}}. {{$step}}
+{{end}}{{end}}
+CONVERSATION:
+{{range .Messages}}- {{.Role}}{{if .Name}} ({{.Name}}){{end}}: {{.Content}}
+{{end}}
+EXPECTED OUTCOME:
+{{.Expected}}
+
+FINAL OUTPUT:
+{{.Output}}
+
+AVAILABLE CONTEXT:
+{{range .Context}}- {{.}}
+{{end}}
+TRACE:
+{{range .Trace}}- kind={{.Kind}} name={{.Name}}{{if .Input}} input={{.Input}}{{end}}{{if .Output}} output={{.Output}}{{end}}{{if .Error}} error={{.Error}}{{end}}
+{{end}}
+Return a score from 0.0 (fails the criteria entirely) to 1.0 (meets the
+criteria perfectly).
+
+Respond with a single JSON object and nothing else:
+{"score": <float 0.0-1.0>, "reason": "<one-sentence explanation>"}

--- a/prompts/task_completion.tmpl
+++ b/prompts/task_completion.tmpl
@@ -1,0 +1,22 @@
+You are evaluating whether an agent completed the user's task.
+
+CONVERSATION:
+{{range .Messages}}- {{.Role}}{{if .Name}} ({{.Name}}){{end}}: {{.Content}}
+{{end}}
+EXPECTED OUTCOME:
+{{.Expected}}
+
+FINAL OUTPUT:
+{{.Output}}
+
+AVAILABLE CONTEXT:
+{{range .Context}}- {{.}}
+{{end}}
+TRACE SUMMARY:
+{{range .Trace}}- {{.Kind}} {{.Name}}{{if .Input}} input={{.Input}}{{end}}{{if .Output}} output={{.Output}}{{end}}{{if .Error}} error={{.Error}}{{end}}
+{{end}}
+Score 1.0 when the final output fully satisfies the user goal and expected
+outcome. Score lower for incomplete, unsupported, or incorrect answers.
+
+Respond with a single JSON object and nothing else:
+{"score": <float 0.0-1.0>, "reason": "<one-sentence explanation>"}

--- a/prompts/tool_use_correctness.tmpl
+++ b/prompts/tool_use_correctness.tmpl
@@ -1,0 +1,20 @@
+You are evaluating an agent trace for correct tool and retrieval use.
+
+CONVERSATION:
+{{range .Messages}}- {{.Role}}{{if .Name}} ({{.Name}}){{end}}: {{.Content}}
+{{end}}
+FINAL OUTPUT:
+{{.Output}}
+
+EXPECTED OUTCOME:
+{{.Expected}}
+
+TRACE:
+{{range .Trace}}- kind={{.Kind}} name={{.Name}}{{if .Input}} input={{.Input}}{{end}}{{if .Output}} output={{.Output}}{{end}}{{if .Error}} error={{.Error}}{{end}}
+  {{range .Context}}context: {{.}}
+  {{end}}{{end}}
+Evaluate whether tool and retrieval steps were necessary, correctly sequenced,
+free of avoidable errors, and consistent with the final output.
+
+Respond with a single JSON object and nothing else:
+{"score": <float 0.0-1.0>, "reason": "<one-sentence explanation>"}


### PR DESCRIPTION
## Summary
- add root-package agent trace APIs, AgentMetric, and Runner.RunAgent
- add TaskCompletion, ToolUseCorrectness, and AgentGEval with prompt templates
- add JSON agent dataset loading, tests, docs, changelog, and a standalone agent app example

## Verification
- go test ./...
- go test -race ./...
- golangci-lint run
- go test ./... (examples/agent_app)

Note: devto-go-eval-articulo.md was left untracked and not included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent trace evaluation to `go-eval` with `RunAgent`, agent metrics, and JSON agent datasets. This enables scoring multi-turn workflows and tool/retrieval traces alongside existing metrics, with strict loaders and updated reports.

- **New Features**
  - Core APIs: `Message`, `TraceSpan`, `AgentCase`, `AgentMetric`, `Runner.RunAgent`.
  - Metrics: `TaskCompletion`, `ToolUseCorrectness`, `AgentGEval` with new judge prompts.
  - Datasets: JSON agent datasets via `agent_cases` with loaders (`LoadAgentDataset`, `LoadAgentCases`, `LoadNamedAgentCases` and Decode variants).
  - Runner: same eval gate, timeouts, tracing, and case filtering as `Run`; copies `AgentCase.Metadata` to results; traces are not persisted by default.
  - Docs & example: updated README/getting-started/metrics reference and report template (trace coverage); added `examples/agent_app`, whose test sets `GOEVAL` for runnable demos.

<sup>Written for commit 7b0066118f808a1420378b282720909e16b6954e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added agent trace evaluation for multi-turn workflows with three new metrics: TaskCompletion, ToolUseCorrectness, and AgentGEval.
* Introduced agent dataset format for defining trace-aware evaluation test cases.
* Added RunAgent method to evaluate agent metrics alongside existing evaluation capabilities.
* Included example agent application demonstrating agent evaluation.

**Documentation**
* Updated README, getting-started guide, and metrics reference with agent evaluation details.
* Extended report template to include agent trace coverage insights.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/igcodinap/go-eval/pull/21)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->